### PR TITLE
Cache imports

### DIFF
--- a/dhall_core/src/import.rs
+++ b/dhall_core/src/import.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 /// The beginning of a file path which anchors subsequent path components
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum FilePrefix {
     /// Absolute path
     Absolute,
@@ -14,7 +14,7 @@ pub enum FilePrefix {
 }
 
 /// The location of import (i.e. local vs. remote vs. environment)
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ImportLocation {
     Local(FilePrefix, PathBuf),
     Remote(URL),
@@ -22,7 +22,7 @@ pub enum ImportLocation {
     Missing,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct URL {
     pub scheme: Scheme,
     pub authority: String,
@@ -31,33 +31,33 @@ pub struct URL {
     pub headers: Option<Box<ImportHashed>>,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Scheme {
     HTTP,
     HTTPS,
 }
 
 /// How to interpret the import's contents (i.e. as Dhall code or raw text)
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ImportMode {
     Code,
     RawText,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Hash {
     pub protocol: String,
     pub hash: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ImportHashed {
     pub location: ImportLocation,
     pub hash: Option<Hash>,
 }
 
 /// Reference to an external resource
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Import {
     pub mode: ImportMode,
     pub location_hashed: ImportHashed,


### PR DESCRIPTION
Hi, great project! :smile: 

I have tried to implement the import caching feature (issue #11). I think I'm almost there, but I'm having some issues understanding the Rust compiler errors I'm getting. I am fairly new to Rust, and I thought I could just open a draft PR to share my work so far and hopefully get someone to explain how I could fix this final type error.

In order to implement the caching feature, I need to change a closure from `Fn` to `FnMut` in order to mutate the cache that the closure closes over. I have attempted to modify all the higher order functions in `dhall_core/src/core.rs` to reflect that, but for some reason the compiler won't accept my changes. I get the following error:

```sh
error[E0277]: expected a `std::ops::Fn<(&A,)>` closure, found `F`
   --> dhall_core/src/core.rs:256:14
    |
256 |         self.traverse_ref(
    |              ^^^^^^^^^^^^ expected an `Fn<(&A,)>` closure, found `F`
    |
    = help: the trait `std::ops::Fn<(&A,)>` is not implemented for `F`
    = help: consider adding a `where F: std::ops::Fn<(&A,)>` bound
    = note: required because of the requirements on the impl of `std::ops::FnMut<(&A,)>` for `&F`

error: aborting due to previous error
```

I experimented a bit (as can be seen in the second temporary commit) and I managed to get it to type check by using a made up temporary closure `foo` which as far as I can tell has the exact same type as `map_embed`. This obviously doesn't work, but I thought I should share my attempt at understanding this.
What am I missing? The error message makes it seem like `FnMut` might not be *SubTrait* of `Fn` as I thought it was.

Would love to get some help on this one :smile: And then once I fix this issue, I can clean-up the PR, add comments about the caching mechanism and address any review comments you might have.