### PR TITLE
Store type information everywhere in `Value`

### DIFF
--- a/dhall/src/core/value.rs
+++ b/dhall/src/core/value.rs
@@ -12,7 +12,7 @@ use crate::phase::typecheck::{builtin_to_value, const_to_value};
 use crate::phase::{NormalizedSubExpr, Typed};
 
 #[derive(Debug, Clone, Copy)]
-pub enum Form {
+pub(crate) enum Form {
     /// No constraints; expression may not be normalized at all.
     Unevaled,
     /// Weak Head Normal Form, i.e. normalized up to the first constructor, but subexpressions may
@@ -41,13 +41,13 @@ struct ValueInternal {
 /// sharing computation automatically. Uses a RefCell to share computation.
 /// Can optionally store a type from typechecking to preserve type information.
 #[derive(Clone)]
-pub struct Value(Rc<RefCell<ValueInternal>>);
+pub(crate) struct Value(Rc<RefCell<ValueInternal>>);
 
 /// When a function needs to return either a freshly created ValueF or an existing Value, but
 /// doesn't want to convert both to the same thing, either to avoid unnecessary allocations or to
 /// avoid loss of typ information.
 #[derive(Debug, Clone)]
-pub enum VoVF {
+pub(crate) enum VoVF {
     Value(Value),
     ValueF { val: ValueF, form: Form },
 }
@@ -111,10 +111,7 @@ impl Value {
     pub(crate) fn from_const(c: Const) -> Self {
         const_to_value(c)
     }
-    pub fn const_type() -> Self {
-        Value::from_const(Const::Type)
-    }
-    pub fn from_builtin(b: Builtin) -> Self {
+    pub(crate) fn from_builtin(b: Builtin) -> Self {
         builtin_to_value(b)
     }
 
@@ -234,7 +231,7 @@ impl Value {
 }
 
 impl VoVF {
-    pub fn into_whnf(self) -> ValueF {
+    pub(crate) fn into_whnf(self) -> ValueF {
         match self {
             VoVF::Value(v) => v.to_whnf(),
             VoVF::ValueF {

--- a/dhall/src/core/value.rs
+++ b/dhall/src/core/value.rs
@@ -8,7 +8,7 @@ use crate::core::context::TypecheckContext;
 use crate::core::valuef::ValueF;
 use crate::core::var::{AlphaVar, Shift, Subst};
 use crate::error::{TypeError, TypeMessage};
-use crate::phase::normalize::{apply_any, normalize_whnf, OutputSubExpr};
+use crate::phase::normalize::{apply_any, normalize_whnf};
 use crate::phase::typecheck::{builtin_to_value, const_to_value};
 use crate::phase::{NormalizedSubExpr, Typed};
 
@@ -208,11 +208,11 @@ impl Value {
     pub(crate) fn normalize_to_expr_maybe_alpha(
         &self,
         alpha: bool,
-    ) -> OutputSubExpr {
+    ) -> NormalizedSubExpr {
         self.as_nf().normalize_to_expr_maybe_alpha(alpha)
     }
 
-    pub(crate) fn app_value(&self, th: Value) -> ValueF {
+    pub(crate) fn app(&self, th: Value) -> ValueF {
         apply_any(self.clone(), th)
     }
 

--- a/dhall/src/core/value.rs
+++ b/dhall/src/core/value.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::cell::{Ref, RefCell, RefMut};
 use std::rc::Rc;
 
@@ -228,8 +227,8 @@ impl Value {
         apply_any(self.clone(), v)
     }
 
-    pub(crate) fn get_type(&self) -> Result<Cow<'_, Value>, TypeError> {
-        Ok(Cow::Owned(self.as_internal().get_type()?.clone()))
+    pub(crate) fn get_type(&self) -> Result<Value, TypeError> {
+        Ok(self.as_internal().get_type()?.clone())
     }
 }
 

--- a/dhall/src/core/value.rs
+++ b/dhall/src/core/value.rs
@@ -2,14 +2,14 @@ use std::borrow::Cow;
 use std::cell::{Ref, RefCell, RefMut};
 use std::rc::Rc;
 
-use dhall_syntax::Const;
+use dhall_syntax::{Builtin, Const};
 
 use crate::core::context::TypecheckContext;
 use crate::core::valuef::ValueF;
 use crate::core::var::{AlphaVar, Shift, Subst};
 use crate::error::{TypeError, TypeMessage};
 use crate::phase::normalize::{apply_any, normalize_whnf, OutputSubExpr};
-use crate::phase::typecheck::const_to_value;
+use crate::phase::typecheck::{builtin_to_value, const_to_value};
 use crate::phase::{NormalizedSubExpr, Typed};
 
 #[derive(Debug, Clone, Copy)]
@@ -114,6 +114,9 @@ impl Value {
     }
     pub fn const_type() -> Self {
         Value::from_const(Const::Type)
+    }
+    pub fn from_builtin(b: Builtin) -> Self {
+        builtin_to_value(b)
     }
 
     pub(crate) fn as_const(&self) -> Option<Const> {

--- a/dhall/src/core/value.rs
+++ b/dhall/src/core/value.rs
@@ -116,18 +116,24 @@ impl ValueInternal {
 }
 
 impl Value {
-    pub(crate) fn new(value: ValueF, form: Form, ty: Option<Value>) -> Value {
-        ValueInternal { form, value, ty }.into_value()
-    }
-    // TODO: this is very wrong
-    pub(crate) fn from_valuef_untyped(v: ValueF) -> Value {
-        Value::new(v, Unevaled, None)
+    fn new(value: ValueF, form: Form, ty: Value) -> Value {
+        ValueInternal {
+            form,
+            value,
+            ty: Some(ty),
+        }
+        .into_value()
     }
     pub(crate) fn const_sort() -> Value {
-        Value::new(ValueF::Const(Const::Sort), NF, None)
+        ValueInternal {
+            form: NF,
+            value: ValueF::Const(Const::Sort),
+            ty: None,
+        }
+        .into_value()
     }
     pub(crate) fn from_valuef_and_type(v: ValueF, t: Value) -> Value {
-        Value::new(v, Unevaled, Some(t))
+        Value::new(v, Unevaled, t)
     }
     pub(crate) fn from_const(c: Const) -> Self {
         const_to_value(c)
@@ -286,16 +292,8 @@ impl VoVF {
                 );
                 v
             }
-            VoVF::ValueF { val, form } => Value::new(val, form, Some(ty)),
+            VoVF::ValueF { val, form } => Value::new(val, form, ty),
         }
-    }
-
-    pub(crate) fn app(self, x: Value) -> VoVF {
-        VoVF::Value(match self {
-            VoVF::Value(v) => v.app(x),
-            // TODO: this is very wrong
-            VoVF::ValueF { val, .. } => Value::from_valuef_untyped(val).app(x),
-        })
     }
 }
 

--- a/dhall/src/core/valuef.rs
+++ b/dhall/src/core/valuef.rs
@@ -257,16 +257,6 @@ impl ValueF {
         }
     }
 
-    /// Apply to a valuef
-    pub(crate) fn app(self, val: ValueF) -> ValueF {
-        self.app_valuef(val)
-    }
-
-    /// Apply to a valuef
-    pub(crate) fn app_valuef(self, val: ValueF) -> ValueF {
-        self.app_value(val.into_value_untyped())
-    }
-
     /// Apply to a value
     pub fn app_value(self, th: Value) -> ValueF {
         Value::from_valuef_untyped(self).app_value(th)

--- a/dhall/src/core/valuef.rs
+++ b/dhall/src/core/valuef.rs
@@ -7,8 +7,7 @@ use dhall_syntax::{
 
 use crate::core::value::Value;
 use crate::core::var::{AlphaLabel, AlphaVar, Shift, Subst};
-use crate::phase::normalize::OutputSubExpr;
-use crate::phase::Normalized;
+use crate::phase::{Normalized, NormalizedSubExpr};
 
 /// A semantic value. Subexpressions are Values, which are partially evaluated expressions that are
 /// normalized on-demand.
@@ -59,7 +58,7 @@ impl ValueF {
     }
 
     /// Convert the value to a fully normalized syntactic expression
-    pub(crate) fn normalize_to_expr(&self) -> OutputSubExpr {
+    pub(crate) fn normalize_to_expr(&self) -> NormalizedSubExpr {
         self.normalize_to_expr_maybe_alpha(false)
     }
     /// Convert the value to a fully normalized syntactic expression. Also alpha-normalize
@@ -67,7 +66,7 @@ impl ValueF {
     pub(crate) fn normalize_to_expr_maybe_alpha(
         &self,
         alpha: bool,
-    ) -> OutputSubExpr {
+    ) -> NormalizedSubExpr {
         match self {
             ValueF::Lam(x, t, e) => rc(ExprF::Lam(
                 x.to_label_maybe_alpha(alpha),
@@ -258,8 +257,8 @@ impl ValueF {
     }
 
     /// Apply to a value
-    pub fn app_value(self, th: Value) -> ValueF {
-        Value::from_valuef_untyped(self).app_value(th)
+    pub fn app(self, th: Value) -> ValueF {
+        Value::from_valuef_untyped(self).app(th)
     }
 
     pub fn from_builtin(b: Builtin) -> ValueF {

--- a/dhall/src/core/valuef.rs
+++ b/dhall/src/core/valuef.rs
@@ -65,12 +65,6 @@ impl ValueF {
             form: Form::WHNF,
         }
     }
-    pub(crate) fn into_vovf_nf(self) -> VoVF {
-        VoVF::ValueF {
-            val: self,
-            form: Form::NF,
-        }
-    }
 
     /// Convert the value to a fully normalized syntactic expression
     pub(crate) fn normalize_to_expr(&self) -> NormalizedSubExpr {

--- a/dhall/src/core/valuef.rs
+++ b/dhall/src/core/valuef.rs
@@ -15,7 +15,7 @@ use crate::phase::{Normalized, NormalizedSubExpr};
 /// alpha-equivalence (renaming of bound variables) and beta-equivalence (normalization). It will
 /// recursively normalize as needed.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ValueF {
+pub(crate) enum ValueF {
     /// Closures
     Lam(AlphaLabel, Value, Value),
     Pi(AlphaLabel, Value, Value),
@@ -52,12 +52,6 @@ impl ValueF {
     }
     pub(crate) fn into_value_with_type(self, t: Value) -> Value {
         Value::from_valuef_and_type(self, t)
-    }
-    pub(crate) fn into_vovf_unevaled(self) -> VoVF {
-        VoVF::ValueF {
-            val: self,
-            form: Form::Unevaled,
-        }
     }
     pub(crate) fn into_vovf_whnf(self) -> VoVF {
         VoVF::ValueF {
@@ -265,12 +259,7 @@ impl ValueF {
         }
     }
 
-    /// Apply to a value
-    pub fn app(self, v: Value) -> VoVF {
-        self.into_vovf_unevaled().app(v)
-    }
-
-    pub fn from_builtin(b: Builtin) -> ValueF {
+    pub(crate) fn from_builtin(b: Builtin) -> ValueF {
         ValueF::AppliedBuiltin(b, vec![])
     }
 }

--- a/dhall/src/core/valuef.rs
+++ b/dhall/src/core/valuef.rs
@@ -5,7 +5,7 @@ use dhall_syntax::{
     NaiveDouble, Natural,
 };
 
-use crate::core::value::{Form, Value, VoVF};
+use crate::core::value::Value;
 use crate::core::var::{AlphaLabel, AlphaVar, Shift, Subst};
 use crate::phase::{Normalized, NormalizedSubExpr};
 
@@ -49,12 +49,6 @@ pub(crate) enum ValueF {
 impl ValueF {
     pub(crate) fn into_value_with_type(self, t: Value) -> Value {
         Value::from_valuef_and_type(self, t)
-    }
-    pub(crate) fn into_vovf_whnf(self) -> VoVF {
-        VoVF::ValueF {
-            val: self,
-            form: Form::WHNF,
-        }
     }
 
     /// Convert the value to a fully normalized syntactic expression
@@ -339,7 +333,7 @@ impl Subst<Value> for ValueF {
                 t.subst_shift(var, val),
                 e.subst_shift(&var.under_binder(x), &val.under_binder(x)),
             ),
-            ValueF::Var(v) if v == var => val.to_whnf(),
+            ValueF::Var(v) if v == var => val.to_whnf_ignore_type(),
             ValueF::Var(v) => ValueF::Var(v.shift(-1, var).unwrap()),
             ValueF::Const(c) => ValueF::Const(*c),
             ValueF::BoolLit(b) => ValueF::BoolLit(*b),

--- a/dhall/src/core/valuef.rs
+++ b/dhall/src/core/valuef.rs
@@ -47,9 +47,6 @@ pub(crate) enum ValueF {
 }
 
 impl ValueF {
-    pub(crate) fn into_value_untyped(self) -> Value {
-        Value::from_valuef_untyped(self)
-    }
     pub(crate) fn into_value_with_type(self, t: Value) -> Value {
         Value::from_valuef_and_type(self, t)
     }

--- a/dhall/src/core/valuef.rs
+++ b/dhall/src/core/valuef.rs
@@ -5,7 +5,7 @@ use dhall_syntax::{
     NaiveDouble, Natural,
 };
 
-use crate::core::value::Value;
+use crate::core::value::{Value, VoVF};
 use crate::core::var::{AlphaLabel, AlphaVar, Shift, Subst};
 use crate::phase::{Normalized, NormalizedSubExpr};
 
@@ -55,6 +55,9 @@ impl ValueF {
     }
     pub(crate) fn into_value_simple_type(self) -> Value {
         Value::from_valuef_simple_type(self)
+    }
+    pub(crate) fn into_vovf(self) -> VoVF {
+        VoVF::ValueF(self)
     }
 
     /// Convert the value to a fully normalized syntactic expression
@@ -257,8 +260,8 @@ impl ValueF {
     }
 
     /// Apply to a value
-    pub fn app(self, th: Value) -> ValueF {
-        Value::from_valuef_untyped(self).app(th)
+    pub fn app(self, v: Value) -> VoVF {
+        self.into_vovf().app(v)
     }
 
     pub fn from_builtin(b: Builtin) -> ValueF {

--- a/dhall/src/error/mod.rs
+++ b/dhall/src/error/mod.rs
@@ -54,7 +54,6 @@ pub(crate) enum TypeMessage {
     NotAFunction(Value),
     TypeMismatch(Value, Value, Value),
     AnnotMismatch(Value, Value),
-    Untyped,
     InvalidListElement(usize, Value, Value),
     InvalidListType(Value),
     InvalidOptionalType(Value),

--- a/dhall/src/phase/mod.rs
+++ b/dhall/src/phase/mod.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::fmt::Display;
 use std::path::Path;
 
@@ -121,8 +120,8 @@ impl Typed {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn get_type(&self) -> Result<Cow<'_, Typed>, TypeError> {
-        Ok(Cow::Owned(self.0.get_type()?.into_owned().into_typed()))
+    pub(crate) fn get_type(&self) -> Result<Typed, TypeError> {
+        Ok(self.0.get_type()?.into_typed())
     }
 }
 

--- a/dhall/src/phase/mod.rs
+++ b/dhall/src/phase/mod.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use std::path::Path;
 
-use dhall_syntax::{Const, SubExpr};
+use dhall_syntax::{Builtin, Const, SubExpr};
 
 use crate::core::value::Value;
 use crate::core::valuef::ValueF;
@@ -122,6 +122,39 @@ impl Typed {
     #[allow(dead_code)]
     pub(crate) fn get_type(&self) -> Result<Typed, TypeError> {
         Ok(self.0.get_type()?.into_typed())
+    }
+
+    pub fn make_builtin_type(b: Builtin) -> Self {
+        Typed::from_value(Value::from_builtin(b))
+    }
+    pub fn make_optional_type(t: Typed) -> Self {
+        Typed::from_value(
+            Value::from_builtin(Builtin::Optional).app(t.to_value()),
+        )
+    }
+    pub fn make_list_type(t: Typed) -> Self {
+        Typed::from_value(Value::from_builtin(Builtin::List).app(t.to_value()))
+    }
+    pub fn make_record_type(
+        kts: impl Iterator<Item = (String, Typed)>,
+    ) -> Self {
+        Typed::from_valuef_and_type(
+            ValueF::RecordType(
+                kts.map(|(k, t)| (k.into(), t.into_value())).collect(),
+            ),
+            Typed::const_type(),
+        )
+    }
+    pub fn make_union_type(
+        kts: impl Iterator<Item = (String, Option<Typed>)>,
+    ) -> Self {
+        Typed::from_valuef_and_type(
+            ValueF::UnionType(
+                kts.map(|(k, t)| (k.into(), t.map(|t| t.into_value())))
+                    .collect(),
+            ),
+            Typed::const_type(),
+        )
     }
 }
 

--- a/dhall/src/phase/mod.rs
+++ b/dhall/src/phase/mod.rs
@@ -92,13 +92,13 @@ impl Typed {
     pub(crate) fn from_const(c: Const) -> Self {
         Typed(Value::from_const(c))
     }
-    pub fn from_valuef_and_type(v: ValueF, t: Typed) -> Self {
+    pub(crate) fn from_valuef_and_type(v: ValueF, t: Typed) -> Self {
         Typed(Value::from_valuef_and_type(v, t.into_value()))
     }
     pub(crate) fn from_value(th: Value) -> Self {
         Typed(th)
     }
-    pub fn const_type() -> Self {
+    pub(crate) fn const_type() -> Self {
         Typed::from_const(Const::Type)
     }
 
@@ -108,7 +108,7 @@ impl Typed {
     pub(crate) fn to_expr_alpha(&self) -> NormalizedSubExpr {
         self.0.to_expr_alpha()
     }
-    pub fn to_value(&self) -> Value {
+    pub(crate) fn to_value(&self) -> Value {
         self.0.clone()
     }
     pub(crate) fn into_value(self) -> Value {

--- a/dhall/src/phase/normalize.rs
+++ b/dhall/src/phase/normalize.rs
@@ -61,8 +61,8 @@ macro_rules! make_closure {
     (Some($($rest:tt)*)) => {{
         let v = make_closure!($($rest)*);
         let v_type = v.get_type().expect("Internal type error");
-        ValueF::NEOptionalLit(v)
-            .into_value_with_type(v_type)
+        let opt_v_type = Value::from_builtin(Builtin::Optional).app(v_type);
+        ValueF::NEOptionalLit(v).into_value_with_type(opt_v_type)
     }};
     (1 + $($rest:tt)*) => {
         ValueF::PartialExpr(ExprF::BinOp(

--- a/dhall/src/phase/typecheck.rs
+++ b/dhall/src/phase/typecheck.rs
@@ -291,7 +291,7 @@ fn type_of_builtin<E>(b: Builtin) -> Expr<E> {
 pub(crate) fn builtin_to_value(b: Builtin) -> Value {
     let ctx = TypecheckContext::new();
     Value::from_valuef_and_type(
-        ValueF::PartialExpr(ExprF::Builtin(b)),
+        ValueF::from_builtin(b),
         type_with(&ctx, rc(type_of_builtin(b))).unwrap(),
     )
 }
@@ -399,7 +399,7 @@ fn type_last_layer(
             if &x.get_type()? != t {
                 return mkerr(AnnotMismatch(x.clone(), t.clone()));
             }
-            RetTypeOnly(x.get_type()?)
+            RetWhole(x.clone())
         }
         Assert(t) => {
             match &*t.as_whnf() {
@@ -649,7 +649,10 @@ fn type_last_layer(
                 return mkerr(EquivalenceTypeMismatch(r.clone(), l.clone()));
             }
 
-            RetTypeOnly(Value::from_const(Type))
+            RetWhole(Value::from_valuef_and_type(
+                ValueF::Equivalence(l.clone(), r.clone()),
+                Value::from_const(Type),
+            ))
         }
         BinOp(o, l, r) => {
             let t = builtin_to_value(match o {

--- a/dhall/src/phase/typecheck.rs
+++ b/dhall/src/phase/typecheck.rs
@@ -455,11 +455,11 @@ fn type_last_layer(
                 return mkerr(InvalidListType(t.into_owned()));
             }
 
-            RetTypeOnly(Value::from_valuef_and_type(
+            RetTypeOnly(
                 ValueF::from_builtin(dhall_syntax::Builtin::List)
-                    .app(t.into_owned()),
-                Value::from_const(Type),
-            ))
+                    .app(t.into_owned())
+                    .into_value_simple_type(),
+            )
         }
         SomeLit(x) => {
             let t = x.get_type()?.into_owned();
@@ -467,10 +467,11 @@ fn type_last_layer(
                 return mkerr(InvalidOptionalType(t));
             }
 
-            RetTypeOnly(Value::from_valuef_and_type(
-                ValueF::from_builtin(dhall_syntax::Builtin::Optional).app(t),
-                Value::from_const(Type),
-            ))
+            RetTypeOnly(
+                Value::from_builtin(dhall_syntax::Builtin::Optional)
+                    .app(t)
+                    .into_value_simple_type(),
+            )
         }
         RecordType(kts) => RetWhole(tck_record_type(
             ctx,

--- a/dhall/src/phase/typecheck.rs
+++ b/dhall/src/phase/typecheck.rs
@@ -129,21 +129,16 @@ fn function_check(a: Const, b: Const) -> Const {
     }
 }
 
-fn type_of_const(c: Const) -> Result<Value, TypeError> {
-    match c {
-        Const::Type => Ok(const_to_value(Const::Kind)),
-        Const::Kind => Ok(const_to_value(Const::Sort)),
-        Const::Sort => {
-            Err(TypeError::new(&TypecheckContext::new(), TypeMessage::Sort))
-        }
-    }
-}
-
 pub(crate) fn const_to_value(c: Const) -> Value {
     let v = ValueF::Const(c);
-    match type_of_const(c) {
-        Ok(t) => Value::from_valuef_and_type(v, t),
-        Err(_) => Value::from_valuef_untyped(v),
+    match c {
+        Const::Type => {
+            Value::from_valuef_and_type(v, const_to_value(Const::Kind))
+        }
+        Const::Kind => {
+            Value::from_valuef_and_type(v, const_to_value(Const::Sort))
+        }
+        Const::Sort => Value::const_sort(),
     }
 }
 

--- a/dhall/src/phase/typecheck.rs
+++ b/dhall/src/phase/typecheck.rs
@@ -455,11 +455,7 @@ fn type_last_layer(
                 return mkerr(InvalidListType(t));
             }
 
-            RetTypeOnly(
-                ValueF::from_builtin(dhall_syntax::Builtin::List)
-                    .app(t)
-                    .into_value_simple_type(),
-            )
+            RetTypeOnly(Value::from_builtin(dhall_syntax::Builtin::List).app(t))
         }
         SomeLit(x) => {
             let t = x.get_type()?;
@@ -468,9 +464,7 @@ fn type_last_layer(
             }
 
             RetTypeOnly(
-                Value::from_builtin(dhall_syntax::Builtin::Optional)
-                    .app(t)
-                    .into_value_simple_type(),
+                Value::from_builtin(dhall_syntax::Builtin::Optional).app(t),
             )
         }
         RecordType(kts) => RetWhole(tck_record_type(

--- a/dhall/src/phase/typecheck.rs
+++ b/dhall/src/phase/typecheck.rs
@@ -457,7 +457,7 @@ fn type_last_layer(
 
             RetTypeOnly(Value::from_valuef_and_type(
                 ValueF::from_builtin(dhall_syntax::Builtin::List)
-                    .app_value(t.into_owned()),
+                    .app(t.into_owned()),
                 Value::from_const(Type),
             ))
         }
@@ -468,8 +468,7 @@ fn type_last_layer(
             }
 
             RetTypeOnly(Value::from_valuef_and_type(
-                ValueF::from_builtin(dhall_syntax::Builtin::Optional)
-                    .app_value(t),
+                ValueF::from_builtin(dhall_syntax::Builtin::Optional).app(t),
                 Value::from_const(Type),
             ))
         }

--- a/dhall/src/tests.rs
+++ b/dhall/src/tests.rs
@@ -185,7 +185,7 @@ pub fn run_test(
                 }
                 TypeInference => {
                     let expr = expr.typecheck()?;
-                    let ty = expr.get_type()?.into_owned().normalize();
+                    let ty = expr.get_type()?.normalize();
                     assert_eq_display!(ty, expected);
                 }
                 Normalization => {

--- a/serde_dhall/src/lib.rs
+++ b/serde_dhall/src/lib.rs
@@ -169,12 +169,16 @@ pub mod value {
         }
         pub(crate) fn make_optional_type(t: Value) -> Self {
             Self::make_simple_type(
-                DhallValueF::from_builtin(Builtin::Optional).app(t.to_value()),
+                DhallValueF::from_builtin(Builtin::Optional)
+                    .app(t.to_value())
+                    .into_whnf(),
             )
         }
         pub(crate) fn make_list_type(t: Value) -> Self {
             Self::make_simple_type(
-                DhallValueF::from_builtin(Builtin::List).app(t.to_value()),
+                DhallValueF::from_builtin(Builtin::List)
+                    .app(t.to_value())
+                    .into_whnf(),
             )
         }
         // Made public for the StaticType derive macro

--- a/serde_dhall/src/lib.rs
+++ b/serde_dhall/src/lib.rs
@@ -169,14 +169,12 @@ pub mod value {
         }
         pub(crate) fn make_optional_type(t: Value) -> Self {
             Self::make_simple_type(
-                DhallValueF::from_builtin(Builtin::Optional)
-                    .app_value(t.to_value()),
+                DhallValueF::from_builtin(Builtin::Optional).app(t.to_value()),
             )
         }
         pub(crate) fn make_list_type(t: Value) -> Self {
             Self::make_simple_type(
-                DhallValueF::from_builtin(Builtin::List)
-                    .app_value(t.to_value()),
+                DhallValueF::from_builtin(Builtin::List).app(t.to_value()),
             )
         }
         // Made public for the StaticType derive macro

--- a/tests_buffer
+++ b/tests_buffer
@@ -28,6 +28,8 @@ variables across import boundaries
     TextLitNested1 "${""}${x}"
     TextLitNested2 "${"${x}"}"
     TextLitNested3 "${"${""}"}${x}"
+    regression/
+        NaturalFoldExtraArg Natural/fold 0 (Bool -> Bool) (λ(_ : (Bool -> Bool)) → λ(_ : Bool) → True) (λ(_ : Bool) → False) True
 
 typecheck:
 something that involves destructuring a recordtype after merge

--- a/tests_buffer
+++ b/tests_buffer
@@ -32,7 +32,9 @@ variables across import boundaries
 typecheck:
 something that involves destructuring a recordtype after merge
 add some of the more complicated Prelude tests back, like List/enumerate
-failure on old-style optional literal
+success/
+    regression/
+        RecursiveRecordTypeMergeTripleCollision { x : { a : Bool } } ⩓ { x : { b : Bool } } ⩓ { x : { c : Bool } }
 failure/
     merge { x = λ(x : Bool) → x } (< x: Bool | y: Natural >.x True)
     merge { x = λ(_ : Bool) → _, y = 1 } < x = True | y >

--- a/tests_buffer
+++ b/tests_buffer
@@ -35,6 +35,9 @@ add some of the more complicated Prelude tests back, like List/enumerate
 success/
     regression/
         RecursiveRecordTypeMergeTripleCollision { x : { a : Bool } } ⩓ { x : { b : Bool } } ⩓ { x : { c : Bool } }
+        somehow test that ({ x = { z = 1 } } ∧ { x = { y = 2 } }).x has a type
+        somehow test that the recordtype from List/indexed has a type in both empty and nonempty cases
+        somehow test types added to the Foo/build closures
 failure/
     merge { x = λ(x : Bool) → x } (< x: Bool | y: Natural >.x True)
     merge { x = λ(_ : Bool) → _, y = 1 } < x = True | y >

--- a/tests_buffer
+++ b/tests_buffer
@@ -41,5 +41,6 @@ failure/
     merge {x=...,y=...} <x:T>.x
     MergeBoolIsNotUnion merge x True
     MergeOptionalIsNotUnion merge x (Some 1)
+    SortInLet let x = Sort in 1
 
 equivalence:


### PR DESCRIPTION
For consistency and simplicity, I prefer storing type info everywhere even if it's not necessary rather than storing it only in some places and hoping we didn't forget somewhere important. For example, a convoluted `//\\` expression would fail to typecheck because types weren't kept around when normalizing `//\\`. Now types are everywhere, and I believe this makes the mental model of `Value` simpler.