### PR TITLE
Tweak tests to avoid double compilation

### DIFF
--- a/dhall/src/lib.rs
+++ b/dhall/src/lib.rs
@@ -11,7 +11,6 @@
     clippy::ptr_arg
 )]
 
-#[cfg(test)]
 #[macro_use]
 mod tests;
 

--- a/dhall/src/phase/mod.rs
+++ b/dhall/src/phase/mod.rs
@@ -119,7 +119,6 @@ impl Typed {
         self.0.normalize_mut()
     }
 
-    #[allow(dead_code)]
     pub(crate) fn get_type(&self) -> Result<Typed, TypeError> {
         Ok(self.0.get_type()?.into_typed())
     }
@@ -166,7 +165,6 @@ impl Normalized {
     pub(crate) fn to_expr(&self) -> NormalizedSubExpr {
         self.0.to_expr()
     }
-    #[allow(dead_code)]
     pub(crate) fn to_expr_alpha(&self) -> NormalizedSubExpr {
         self.0.to_expr_alpha()
     }

--- a/dhall/src/tests.rs
+++ b/dhall/src/tests.rs
@@ -1,3 +1,6 @@
+#[cfg(not(test))]
+use assert_eq as assert_eq_pretty;
+#[cfg(test)]
 use pretty_assertions::assert_eq as assert_eq_pretty;
 
 macro_rules! assert_eq_display {
@@ -40,6 +43,7 @@ use std::path::PathBuf;
 use crate::error::{Error, Result};
 use crate::phase::Parsed;
 
+#[allow(dead_code)]
 #[derive(Copy, Clone)]
 pub enum Feature {
     Parser,
@@ -53,6 +57,7 @@ pub enum Feature {
     TypeInference,
 }
 
+#[allow(dead_code)]
 #[derive(Copy, Clone)]
 pub enum Status {
     Success,
@@ -63,6 +68,7 @@ fn parse_file_str<'i>(file_path: &str) -> Result<Parsed> {
     Parsed::parse_file(&PathBuf::from(file_path))
 }
 
+#[allow(dead_code)]
 pub fn run_test_stringy_error(
     base_path: &str,
     feature: Feature,
@@ -241,6 +247,7 @@ pub fn run_test(
     Ok(())
 }
 
+#[cfg(test)]
 mod spec {
     // See build.rs
     include!(concat!(env!("OUT_DIR"), "/spec_tests.rs"));


### PR DESCRIPTION
Every time I compiled the `dhall` crate with tests enabled, it got compiled twice for some reason. I just figured out the reason: when tests are enabled, a macro gets exported into the scope of the whole crate, so rust recompiles the whole crate just in case.
This fixes that.