### PR TITLE
Rework parser macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,6 @@ dependencies = [
  "dhall_generated_parser 0.1.0",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "improved_slice_patterns 2.0.0",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/dhall_generated_parser/src/dhall.pest.visibility
+++ b/dhall_generated_parser/src/dhall.pest.visibility
@@ -141,7 +141,7 @@ hash
 import_hashed
 import
 expression
-annotated_expression
+# annotated_expression
 let_binding
 empty_list_literal
 operator_expression

--- a/dhall_generated_parser/src/dhall.pest.visibility
+++ b/dhall_generated_parser/src/dhall.pest.visibility
@@ -160,7 +160,7 @@ not_equal_expression
 equivalent_expression
 application_expression
 first_application_expression
-# import_expression
+import_expression
 selector_expression
 selector
 labels

--- a/dhall_generated_parser/src/dhall.pest.visibility
+++ b/dhall_generated_parser/src/dhall.pest.visibility
@@ -106,7 +106,7 @@ unquoted_path_component
 quoted_path_component
 path_component
 path
-# local
+local
 parent_path
 here_path
 home_path

--- a/dhall_syntax/Cargo.toml
+++ b/dhall_syntax/Cargo.toml
@@ -16,4 +16,3 @@ either = "1.5.2"
 take_mut = "0.2.2"
 hex = "0.3.2"
 dhall_generated_parser = { path = "../dhall_generated_parser" }
-improved_slice_patterns = { version = "2.0.0", path = "../improved_slice_patterns" }

--- a/dhall_syntax/src/lib.rs
+++ b/dhall_syntax/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(slice_patterns)]
 #![feature(try_blocks)]
 #![feature(never_type)]
+#![feature(bind_by_move_pattern_guards)]
 #![allow(
     clippy::many_single_char_names,
     clippy::should_implement_trait,

--- a/dhall_syntax/src/parser.rs
+++ b/dhall_syntax/src/parser.rs
@@ -120,52 +120,52 @@ fn debug_pair(pair: Pair<Rule>) -> String {
 }
 
 macro_rules! make_parser {
-    (@child_pattern,
+    (@children_pattern,
         $varpat:ident,
         ($($acc:tt)*),
         [$variant:ident ($x:pat), $($rest:tt)*]
     ) => (
-        make_parser!(@child_pattern,
+        make_parser!(@children_pattern,
             $varpat,
             ($($acc)* , Rule::$variant),
             [$($rest)*]
         )
     );
-    (@child_pattern,
+    (@children_pattern,
         $varpat:ident,
         ($($acc:tt)*),
         [$variant:ident ($x:ident).., $($rest:tt)*]
     ) => (
-        make_parser!(@child_pattern,
+        make_parser!(@children_pattern,
             $varpat,
             ($($acc)* , $varpat..),
             [$($rest)*]
         )
     );
-    (@child_pattern,
+    (@children_pattern,
         $varpat:ident,
         (, $($acc:tt)*), [$(,)*]
     ) => ([$($acc)*]);
-    (@child_pattern,
+    (@children_pattern,
         $varpat:ident,
         ($($acc:tt)*), [$(,)*]
     ) => ([$($acc)*]);
 
-    (@child_filter,
+    (@children_filter,
         $varpat:ident,
         [$variant:ident ($x:pat), $($rest:tt)*]
     ) => (
         true &&
-        make_parser!(@child_filter, $varpat, [$($rest)*])
+        make_parser!(@children_filter, $varpat, [$($rest)*])
     );
-    (@child_filter,
+    (@children_filter,
         $varpat:ident,
         [$variant:ident ($x:ident).., $($rest:tt)*]
     ) => (
         $varpat.iter().all(|r| r == &Rule::$variant) &&
-        make_parser!(@child_filter, $varpat, [$($rest)*])
+        make_parser!(@children_filter, $varpat, [$($rest)*])
     );
-    (@child_filter, $varpat:ident, [$(,)*]) => (true);
+    (@children_filter, $varpat:ident, [$(,)*]) => (true);
 
     (@rule_alias,
         rule!( $name:ident<$o:ty>; $($args:tt)* )
@@ -234,8 +234,8 @@ macro_rules! make_parser {
 
             match children_rules.as_slice() {
                 $(
-                    make_parser!(@child_pattern, x, (), [$($args)*,])
-                    if make_parser!(@child_filter, x, [$($args)*,])
+                    make_parser!(@children_pattern, x, (), [$($args)*,])
+                    if make_parser!(@children_filter, x, [$($args)*,])
                     => {
                         let ret =
                             improved_slice_patterns::destructure_iter!(iter;

--- a/dhall_syntax/src/parser.rs
+++ b/dhall_syntax/src/parser.rs
@@ -328,7 +328,7 @@ macro_rules! make_parser {
     });
     (@body,
         ($($things:tt)*),
-        token_rule!($name:ident<$o:ty>)
+        rule!($name:ident<$o:ty>)
     ) => ({
         Ok(())
     });
@@ -428,7 +428,7 @@ fn trim_indent(lines: &mut Vec<ParsedText>) {
 }
 
 make_parser! {
-    token_rule!(EOI<()>);
+    rule!(EOI<()>);
 
     rule!(simple_label<Label>;
         captured_str!(s) => Label::from(s.trim().to_owned())
@@ -611,9 +611,9 @@ make_parser! {
         }
     );
 
-    token_rule!(NaN<()>);
-    token_rule!(minus_infinity_literal<()>);
-    token_rule!(plus_infinity_literal<()>);
+    rule!(NaN<()>);
+    rule!(minus_infinity_literal<()>);
+    rule!(plus_infinity_literal<()>);
 
     rule!(numeric_double_literal<core::Double>;
         captured_str!(s) => {
@@ -762,7 +762,7 @@ make_parser! {
         }
     );
 
-    token_rule!(missing<()>);
+    rule!(missing<()>);
 
     rule!(import_type<ImportLocation<ParsedSubExpr>>; children!(
         [missing(_)] => {
@@ -796,8 +796,8 @@ make_parser! {
             crate::Import {mode: ImportMode::Code, location, hash: Some(h) },
     ));
 
-    token_rule!(Text<()>);
-    token_rule!(Location<()>);
+    rule!(Text<()>);
+    rule!(Location<()>);
 
     rule!(import<ParsedSubExpr>; span; children!(
         [import_hashed(imp)] => {
@@ -820,13 +820,13 @@ make_parser! {
         },
     ));
 
-    token_rule!(lambda<()>);
-    token_rule!(forall<()>);
-    token_rule!(arrow<()>);
-    token_rule!(merge<()>);
-    token_rule!(assert<()>);
-    token_rule!(if_<()>);
-    token_rule!(in_<()>);
+    rule!(lambda<()>);
+    rule!(forall<()>);
+    rule!(arrow<()>);
+    rule!(merge<()>);
+    rule!(assert<()>);
+    rule!(if_<()>);
+    rule!(in_<()>);
 
     rule!(empty_list_literal<ParsedSubExpr>; span; children!(
         [application_expression(e)] => {
@@ -877,8 +877,8 @@ make_parser! {
             (name, None, expr),
     ));
 
-    token_rule!(List<()>);
-    token_rule!(Optional<()>);
+    rule!(List<()>);
+    rule!(Optional<()>);
 
     rule!(operator_expression<ParsedSubExpr>; prec_climb!(
         application_expression,
@@ -933,8 +933,8 @@ make_parser! {
         }
     ));
 
-    token_rule!(Some_<()>);
-    token_rule!(toMap<()>);
+    rule!(Some_<()>);
+    rule!(toMap<()>);
 
     rule!(application_expression<ParsedSubExpr>; children!(
         [first_application_expression(e)] => e,
@@ -1048,7 +1048,7 @@ make_parser! {
         },
     ));
 
-    token_rule!(empty_union_type<()>);
+    rule!(empty_union_type<()>);
 
     rule!(union_type_entry<(Label, Option<ParsedSubExpr>)>; children!(
         [label(name), expression(expr)] => (name, Some(expr)),

--- a/tests_buffer
+++ b/tests_buffer
@@ -9,6 +9,7 @@ success/
         PrecedenceAll2 a b != c == d * e ⩓ f ⫽ g ∧ h && i # j ++ k + l || m ? n
     LetNoAnnot let x = y in e
     LetAnnot let x: T = y in e
+    EmptyRecordLiteral {=}
 failure/
     AssertNoAnnotation assert
 


### PR DESCRIPTION
Reworks parser macros to avoid needing the large ParsedValue enum