### PR TITLE
Rename SubExpr to Expr

### DIFF
--- a/dhall/src/core/value.rs
+++ b/dhall/src/core/value.rs
@@ -9,7 +9,7 @@ use crate::core::var::{AlphaVar, Shift, Subst};
 use crate::error::{TypeError, TypeMessage};
 use crate::phase::normalize::{apply_any, normalize_whnf};
 use crate::phase::typecheck::{builtin_to_value, const_to_value};
-use crate::phase::{NormalizedSubExpr, Typed};
+use crate::phase::{NormalizedExpr, Typed};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum Form {
@@ -166,11 +166,11 @@ impl Value {
     }
 
     // TODO: rename `normalize_to_expr`
-    pub(crate) fn to_expr(&self) -> NormalizedSubExpr {
+    pub(crate) fn to_expr(&self) -> NormalizedExpr {
         self.as_whnf().normalize_to_expr()
     }
     // TODO: rename `normalize_to_expr_maybe_alpha`
-    pub(crate) fn to_expr_alpha(&self) -> NormalizedSubExpr {
+    pub(crate) fn to_expr_alpha(&self) -> NormalizedExpr {
         self.as_whnf().normalize_to_expr_maybe_alpha(true)
     }
     pub(crate) fn to_whnf_ignore_type(&self) -> ValueF {
@@ -226,7 +226,7 @@ impl Value {
     pub(crate) fn normalize_to_expr_maybe_alpha(
         &self,
         alpha: bool,
-    ) -> NormalizedSubExpr {
+    ) -> NormalizedExpr {
         self.as_nf().normalize_to_expr_maybe_alpha(alpha)
     }
 

--- a/dhall/src/core/valuef.rs
+++ b/dhall/src/core/valuef.rs
@@ -7,7 +7,7 @@ use dhall_syntax::{
 
 use crate::core::value::Value;
 use crate::core::var::{AlphaLabel, AlphaVar, Shift, Subst};
-use crate::phase::{Normalized, NormalizedSubExpr};
+use crate::phase::{Normalized, NormalizedExpr};
 
 /// A semantic value. Subexpressions are Values, which are partially evaluated expressions that are
 /// normalized on-demand.
@@ -52,7 +52,7 @@ impl ValueF {
     }
 
     /// Convert the value to a fully normalized syntactic expression
-    pub(crate) fn normalize_to_expr(&self) -> NormalizedSubExpr {
+    pub(crate) fn normalize_to_expr(&self) -> NormalizedExpr {
         self.normalize_to_expr_maybe_alpha(false)
     }
     /// Convert the value to a fully normalized syntactic expression. Also alpha-normalize
@@ -60,7 +60,7 @@ impl ValueF {
     pub(crate) fn normalize_to_expr_maybe_alpha(
         &self,
         alpha: bool,
-    ) -> NormalizedSubExpr {
+    ) -> NormalizedExpr {
         match self {
             ValueF::Lam(x, t, e) => rc(ExprF::Lam(
                 x.to_label_maybe_alpha(alpha),

--- a/dhall/src/error/mod.rs
+++ b/dhall/src/error/mod.rs
@@ -5,7 +5,7 @@ use dhall_syntax::{BinOp, Import, Label, ParseError, V};
 use crate::core::context::TypecheckContext;
 use crate::core::value::Value;
 use crate::phase::resolve::ImportStack;
-use crate::phase::NormalizedSubExpr;
+use crate::phase::NormalizedExpr;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -22,9 +22,9 @@ pub enum Error {
 
 #[derive(Debug)]
 pub enum ImportError {
-    Recursive(Import<NormalizedSubExpr>, Box<Error>),
-    UnexpectedImport(Import<NormalizedSubExpr>),
-    ImportCycle(ImportStack, Import<NormalizedSubExpr>),
+    Recursive(Import<NormalizedExpr>, Box<Error>),
+    UnexpectedImport(Import<NormalizedExpr>),
+    ImportCycle(ImportStack, Import<NormalizedExpr>),
 }
 
 #[derive(Debug)]

--- a/dhall/src/phase/mod.rs
+++ b/dhall/src/phase/mod.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use std::path::Path;
 
-use dhall_syntax::{Builtin, Const, SubExpr};
+use dhall_syntax::{Builtin, Const, Expr};
 
 use crate::core::value::Value;
 use crate::core::valuef::ValueF;
@@ -16,19 +16,19 @@ pub(crate) mod parse;
 pub(crate) mod resolve;
 pub(crate) mod typecheck;
 
-pub type ParsedSubExpr = SubExpr<!>;
-pub type DecodedSubExpr = SubExpr<!>;
-pub type ResolvedSubExpr = SubExpr<Normalized>;
-pub type NormalizedSubExpr = SubExpr<Normalized>;
+pub type ParsedExpr = Expr<!>;
+pub type DecodedExpr = Expr<!>;
+pub type ResolvedExpr = Expr<Normalized>;
+pub type NormalizedExpr = Expr<Normalized>;
 
 #[derive(Debug, Clone)]
-pub struct Parsed(ParsedSubExpr, ImportRoot);
+pub struct Parsed(ParsedExpr, ImportRoot);
 
 /// An expression where all imports have been resolved
 ///
 /// Invariant: there must be no `Import` nodes or `ImportAlt` operations left.
 #[derive(Debug, Clone)]
-pub struct Resolved(ResolvedSubExpr);
+pub struct Resolved(ResolvedExpr);
 
 /// A typed expression
 #[derive(Debug, Clone)]
@@ -102,10 +102,10 @@ impl Typed {
         Typed::from_const(Const::Type)
     }
 
-    pub fn to_expr(&self) -> NormalizedSubExpr {
+    pub fn to_expr(&self) -> NormalizedExpr {
         self.0.to_expr()
     }
-    pub(crate) fn to_expr_alpha(&self) -> NormalizedSubExpr {
+    pub(crate) fn to_expr_alpha(&self) -> NormalizedExpr {
         self.0.to_expr_alpha()
     }
     pub(crate) fn to_value(&self) -> Value {
@@ -162,10 +162,10 @@ impl Normalized {
         crate::phase::binary::encode(&self.to_expr())
     }
 
-    pub(crate) fn to_expr(&self) -> NormalizedSubExpr {
+    pub(crate) fn to_expr(&self) -> NormalizedExpr {
         self.0.to_expr()
     }
-    pub(crate) fn to_expr_alpha(&self) -> NormalizedSubExpr {
+    pub(crate) fn to_expr_alpha(&self) -> NormalizedExpr {
         self.0.to_expr_alpha()
     }
     pub(crate) fn into_typed(self) -> Typed {

--- a/dhall/src/phase/resolve.rs
+++ b/dhall/src/phase/resolve.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::error::{Error, ImportError};
-use crate::phase::{Normalized, NormalizedSubExpr, Parsed, Resolved};
+use crate::phase::{Normalized, NormalizedExpr, Parsed, Resolved};
 
-type Import = dhall_syntax::Import<NormalizedSubExpr>;
+type Import = dhall_syntax::Import<NormalizedExpr>;
 
 /// A root from which to resolve relative imports.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/dhall_syntax/src/core/visitor.rs
+++ b/dhall_syntax/src/core/visitor.rs
@@ -247,18 +247,17 @@ where
 
 pub struct ResolveVisitor<F1>(pub F1);
 
-impl<'a, 'b, E, E2, Err, F1>
-    ExprFFallibleVisitor<'a, SubExpr<E>, SubExpr<E2>, E, E2>
+impl<'a, 'b, E, E2, Err, F1> ExprFFallibleVisitor<'a, Expr<E>, Expr<E2>, E, E2>
     for &'b mut ResolveVisitor<F1>
 where
-    F1: FnMut(&Import<SubExpr<E2>>) -> Result<E2, Err>,
+    F1: FnMut(&Import<Expr<E2>>) -> Result<E2, Err>,
 {
     type Error = Err;
 
     fn visit_subexpr(
         &mut self,
-        subexpr: &'a SubExpr<E>,
-    ) -> Result<SubExpr<E2>, Self::Error> {
+        subexpr: &'a Expr<E>,
+    ) -> Result<Expr<E2>, Self::Error> {
         Ok(subexpr.rewrap(
             subexpr
                 .as_ref()

--- a/dhall_syntax/src/printer.rs
+++ b/dhall_syntax/src/printer.rs
@@ -112,7 +112,7 @@ enum PrintPhase {
 // Wraps an Expr with a phase, so that phase selsction can be done
 // separate from the actual printing
 #[derive(Clone)]
-struct PhasedExpr<'a, A>(&'a SubExpr<A>, PrintPhase);
+struct PhasedExpr<'a, A>(&'a Expr<A>, PrintPhase);
 
 impl<'a, A: Display + Clone> Display for PhasedExpr<'a, A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
@@ -126,7 +126,7 @@ impl<'a, A: Display + Clone> PhasedExpr<'a, A> {
     }
 }
 
-impl<A: Display + Clone> Expr<A> {
+impl<A: Display + Clone> RawExpr<A> {
     fn fmt_phase(
         &self,
         f: &mut fmt::Formatter,
@@ -202,7 +202,7 @@ impl<A: Display + Clone> Expr<A> {
     }
 }
 
-impl<A: Display + Clone> Display for SubExpr<A> {
+impl<A: Display + Clone> Display for Expr<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         self.as_ref().fmt_phase(f, PrintPhase::Base)
     }

--- a/serde_dhall/src/lib.rs
+++ b/serde_dhall/src/lib.rs
@@ -124,7 +124,7 @@ pub use value::Value;
 
 // A Dhall value.
 pub mod value {
-    use dhall::phase::{NormalizedSubExpr, Parsed, Typed};
+    use dhall::phase::{NormalizedExpr, Parsed, Typed};
     use dhall_syntax::Builtin;
 
     use super::de::{Error, Result};
@@ -148,7 +148,7 @@ pub mod value {
             };
             Ok(Value(typed))
         }
-        pub(crate) fn to_expr(&self) -> NormalizedSubExpr {
+        pub(crate) fn to_expr(&self) -> NormalizedExpr {
             self.0.to_expr()
         }
         pub(crate) fn as_typed(&self) -> &Typed {

--- a/serde_dhall/src/serde.rs
+++ b/serde_dhall/src/serde.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use dhall::phase::NormalizedSubExpr;
+use dhall::phase::NormalizedExpr;
 use dhall_syntax::ExprF;
 
 use crate::de::{Deserialize, Error, Result};
@@ -15,7 +15,7 @@ where
     }
 }
 
-struct Deserializer<'a>(Cow<'a, NormalizedSubExpr>);
+struct Deserializer<'a>(Cow<'a, NormalizedExpr>);
 
 impl<'de: 'a, 'a> serde::de::IntoDeserializer<'de, Error> for Deserializer<'a> {
     type Deserializer = Deserializer<'a>;


### PR DESCRIPTION
(and Expr to RawExpr).
This naming was a leftover from another time, but I don't think it makes sense to call the main expresison type `SubExpr` and the other one that's rarely used `Expr`. So for clarity, and consistency with `Value`, I renamed both of those types.