### PR TITLE
Rewrite parser macros as proc_macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ name = "dhall_proc_macros"
 version = "0.1.0"
 dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -105,6 +105,7 @@ name = "dhall_syntax"
 version = "0.1.0"
 dependencies = [
  "dhall_generated_parser 0.1.0",
+ "dhall_proc_macros 0.1.0",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -270,11 +271,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -345,6 +362,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +411,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -468,13 +500,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pretty 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f60c0d9f6fc88ecdd245d90c1920ff76a430ab34303fc778d33b1d0a4c3bf6d3"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "175a40b9cf564ce9bf050654633dbf339978706b8ead1a907bb970b63185dd95"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
+"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "aa5f7c20820475babd2c077c3ab5f8c77a31c15e16ea38687b4c02d3e48680f4"
 "checksum serde_cbor 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45cd6d95391b16cd57e88b68be41d504183b7faae22030c0cc3b3f73dd57b2fd"
 "checksum serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "58fc82bec244f168b23d1963b45c8bf5726e9a15a9d146a067f9081aeed2de79"
 "checksum sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9d1f3b5de8a167ab06834a7c883bd197f2191e1dda1a22d9ccfeedbf9aded"
 "checksum syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b4cfac95805274c6afdb12d8f770fa2d27c045953e7b630a81801953699a9a"
+"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum term-painter 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "dcaa948f0e3e38470cd8dc8dcfe561a75c9e43f28075bb183845be2b9b3c08cf"
@@ -482,6 +517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-trie 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "71a9c5b1fe77426cf144cc30e49e955270f5086e31a6441dfa8b32efc09b9d77"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -180,6 +181,11 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "maplit"
@@ -489,6 +495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"

--- a/dhall_proc_macros/Cargo.toml
+++ b/dhall_proc_macros/Cargo.toml
@@ -11,6 +11,6 @@ doctest = false
 
 [dependencies]
 itertools = "0.8.0"
-quote = "0.6.11"
-proc-macro2 = "0.4.27"
-syn = "0.15.29"
+quote = "1.0.2"
+proc-macro2 = "1.0.2"
+syn = { version = "1.0.5", features = ["full", "extra-traits"] }

--- a/dhall_proc_macros/src/lib.rs
+++ b/dhall_proc_macros/src/lib.rs
@@ -17,8 +17,8 @@ pub fn derive_static_type(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-pub fn make_parser(_attr: TokenStream, input: TokenStream) -> TokenStream {
-    TokenStream::from(match parser::make_parser(input) {
+pub fn make_parser(attrs: TokenStream, input: TokenStream) -> TokenStream {
+    TokenStream::from(match parser::make_parser(attrs, input) {
         Ok(tokens) => tokens,
         Err(err) => err.to_compile_error(),
     })

--- a/dhall_proc_macros/src/lib.rs
+++ b/dhall_proc_macros/src/lib.rs
@@ -7,7 +7,8 @@
 extern crate proc_macro;
 
 mod derive;
-mod parser;
+mod make_parser;
+mod parse_children;
 
 use proc_macro::TokenStream;
 
@@ -18,7 +19,7 @@ pub fn derive_static_type(input: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn make_parser(attrs: TokenStream, input: TokenStream) -> TokenStream {
-    TokenStream::from(match parser::make_parser(attrs, input) {
+    TokenStream::from(match make_parser::make_parser(attrs, input) {
         Ok(tokens) => tokens,
         Err(err) => err.to_compile_error(),
     })
@@ -26,7 +27,7 @@ pub fn make_parser(attrs: TokenStream, input: TokenStream) -> TokenStream {
 
 #[proc_macro]
 pub fn parse_children(input: TokenStream) -> TokenStream {
-    TokenStream::from(match parser::parse_children(input) {
+    TokenStream::from(match parse_children::parse_children(input) {
         Ok(tokens) => tokens,
         Err(err) => err.to_compile_error(),
     })

--- a/dhall_proc_macros/src/lib.rs
+++ b/dhall_proc_macros/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(drain_filter)]
 //! This crate contains the code-generation primitives for the [dhall-rust][dhall-rust] crate.
 //! This is highly unstable and breaks regularly; use at your own risk.
 //!

--- a/dhall_proc_macros/src/lib.rs
+++ b/dhall_proc_macros/src/lib.rs
@@ -22,3 +22,11 @@ pub fn make_parser(input: TokenStream) -> TokenStream {
         Err(err) => err.to_compile_error(),
     })
 }
+
+#[proc_macro]
+pub fn parse_children(input: TokenStream) -> TokenStream {
+    TokenStream::from(match parser::parse_children(input) {
+        Ok(tokens) => tokens,
+        Err(err) => err.to_compile_error(),
+    })
+}

--- a/dhall_proc_macros/src/lib.rs
+++ b/dhall_proc_macros/src/lib.rs
@@ -15,8 +15,8 @@ pub fn derive_static_type(input: TokenStream) -> TokenStream {
     derive::derive_static_type(input)
 }
 
-#[proc_macro]
-pub fn make_parser(input: TokenStream) -> TokenStream {
+#[proc_macro_attribute]
+pub fn make_parser(_attr: TokenStream, input: TokenStream) -> TokenStream {
     TokenStream::from(match parser::make_parser(input) {
         Ok(tokens) => tokens,
         Err(err) => err.to_compile_error(),

--- a/dhall_proc_macros/src/lib.rs
+++ b/dhall_proc_macros/src/lib.rs
@@ -6,10 +6,19 @@
 extern crate proc_macro;
 
 mod derive;
+mod parser;
 
 use proc_macro::TokenStream;
 
 #[proc_macro_derive(StaticType)]
 pub fn derive_static_type(input: TokenStream) -> TokenStream {
     derive::derive_static_type(input)
+}
+
+#[proc_macro]
+pub fn make_parser(input: TokenStream) -> TokenStream {
+    TokenStream::from(match parser::make_parser(input) {
+        Ok(tokens) => tokens,
+        Err(err) => err.to_compile_error(),
+    })
 }

--- a/dhall_proc_macros/src/make_parser.rs
+++ b/dhall_proc_macros/src/make_parser.rs
@@ -1,0 +1,90 @@
+use quote::quote;
+use syn::parse::{ParseStream, Result};
+use syn::spanned::Spanned;
+use syn::{
+    parse_quote, Error, Expr, Ident, ImplItem, ImplItemMethod, ItemImpl,
+    ReturnType, Token,
+};
+
+fn apply_special_attrs(
+    rule_enum: &Ident,
+    function: &mut ImplItemMethod,
+) -> Result<()> {
+    let recognized_attrs: Vec<_> = function
+        .attrs
+        .drain_filter(|attr| attr.path.is_ident("prec_climb"))
+        .collect();
+
+    let name = function.sig.ident.clone();
+    let output_type = match &function.sig.output {
+        ReturnType::Default => parse_quote!(()),
+        ReturnType::Type(_, t) => (**t).clone(),
+    };
+
+    if recognized_attrs.is_empty() {
+    } else if recognized_attrs.len() > 1 {
+        return Err(Error::new(
+            recognized_attrs[1].span(),
+            "expected a single prec_climb attribute",
+        ));
+    } else {
+        let attr = recognized_attrs.into_iter().next().unwrap();
+        let (child_rule, climber) =
+            attr.parse_args_with(|input: ParseStream| {
+                let child_rule: Ident = input.parse()?;
+                let _: Token![,] = input.parse()?;
+                let climber: Expr = input.parse()?;
+                Ok((child_rule, climber))
+            })?;
+
+        *function = parse_quote!(
+            fn #name<'a>(
+                input: ParseInput<'a, #rule_enum>,
+            ) -> #output_type {
+                #[allow(non_snake_case, dead_code)]
+                #function
+
+                #climber.climb(
+                    input.pair.clone().into_inner(),
+                    |p| Self::#child_rule(input.with_pair(p)),
+                    |l, op, r| {
+                        #name(input.clone(), l?, op, r?)
+                    },
+                )
+            }
+        );
+    }
+
+    *function = parse_quote!(
+        #[allow(non_snake_case, dead_code)]
+        #function
+    );
+
+    Ok(())
+}
+
+pub fn make_parser(
+    attrs: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> Result<proc_macro2::TokenStream> {
+    let rule_enum: Ident = syn::parse(attrs)?;
+
+    let mut imp: ItemImpl = syn::parse(input)?;
+    imp.items
+        .iter_mut()
+        .map(|item| match item {
+            ImplItem::Method(m) => apply_special_attrs(&rule_enum, m),
+            _ => Ok(()),
+        })
+        .collect::<Result<()>>()?;
+
+    let ty = &imp.self_ty;
+    let (impl_generics, _, where_clause) = imp.generics.split_for_impl();
+    Ok(quote!(
+        impl #impl_generics PestConsumer for #ty #where_clause {
+            type RuleEnum = #rule_enum;
+        }
+
+        #imp
+    ))
+}

--- a/dhall_proc_macros/src/parse_children.rs
+++ b/dhall_proc_macros/src/parse_children.rs
@@ -3,10 +3,7 @@ use quote::quote;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{
-    bracketed, parenthesized, parse_quote, token, Error, Expr, Ident, ImplItem,
-    ImplItemMethod, ItemImpl, Pat, ReturnType, Token,
-};
+use syn::{bracketed, parenthesized, token, Error, Expr, Ident, Pat, Token};
 
 #[derive(Debug, Clone)]
 struct ChildrenBranch {
@@ -74,89 +71,6 @@ impl Parse for ParseChildrenInput {
             branches,
         })
     }
-}
-
-fn apply_special_attrs(
-    rule_enum: &Ident,
-    function: &mut ImplItemMethod,
-) -> Result<()> {
-    let recognized_attrs: Vec<_> = function
-        .attrs
-        .drain_filter(|attr| attr.path.is_ident("prec_climb"))
-        .collect();
-
-    let name = function.sig.ident.clone();
-    let output_type = match &function.sig.output {
-        ReturnType::Default => parse_quote!(()),
-        ReturnType::Type(_, t) => (**t).clone(),
-    };
-
-    if recognized_attrs.is_empty() {
-    } else if recognized_attrs.len() > 1 {
-        return Err(Error::new(
-            recognized_attrs[1].span(),
-            "expected a single prec_climb attribute",
-        ));
-    } else {
-        let attr = recognized_attrs.into_iter().next().unwrap();
-        let (child_rule, climber) =
-            attr.parse_args_with(|input: ParseStream| {
-                let child_rule: Ident = input.parse()?;
-                let _: Token![,] = input.parse()?;
-                let climber: Expr = input.parse()?;
-                Ok((child_rule, climber))
-            })?;
-
-        *function = parse_quote!(
-            fn #name<'a>(
-                input: ParseInput<'a, #rule_enum>,
-            ) -> #output_type {
-                #[allow(non_snake_case, dead_code)]
-                #function
-
-                #climber.climb(
-                    input.pair.clone().into_inner(),
-                    |p| Self::#child_rule(input.with_pair(p)),
-                    |l, op, r| {
-                        #name(input.clone(), l?, op, r?)
-                    },
-                )
-            }
-        );
-    }
-
-    *function = parse_quote!(
-        #[allow(non_snake_case, dead_code)]
-        #function
-    );
-
-    Ok(())
-}
-
-pub fn make_parser(
-    attrs: proc_macro::TokenStream,
-    input: proc_macro::TokenStream,
-) -> Result<proc_macro2::TokenStream> {
-    let rule_enum: Ident = syn::parse(attrs)?;
-
-    let mut imp: ItemImpl = syn::parse(input)?;
-    imp.items
-        .iter_mut()
-        .map(|item| match item {
-            ImplItem::Method(m) => apply_special_attrs(&rule_enum, m),
-            _ => Ok(()),
-        })
-        .collect::<Result<()>>()?;
-
-    let ty = &imp.self_ty;
-    let (impl_generics, _, where_clause) = imp.generics.split_for_impl();
-    Ok(quote!(
-        impl #impl_generics PestConsumer for #ty #where_clause {
-            type RuleEnum = #rule_enum;
-        }
-
-        #imp
-    ))
 }
 
 fn make_parser_branch(branch: &ChildrenBranch) -> Result<TokenStream> {

--- a/dhall_proc_macros/src/parser.rs
+++ b/dhall_proc_macros/src/parser.rs
@@ -4,8 +4,8 @@ use syn::parse::{Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
-    bracketed, parenthesized, parse_quote, token, Error, Expr, Ident, ItemFn,
-    Pat, ReturnType, Token, Type,
+    braced, bracketed, parenthesized, parse_quote, token, Error, Expr, Ident,
+    ItemFn, Pat, ReturnType, Token, Type,
 };
 
 mod rule_kw {
@@ -58,9 +58,13 @@ struct ParseChildrenInput {
 
 impl Parse for Rules {
     fn parse(input: ParseStream) -> Result<Self> {
+        let _: Token![impl ] = input.parse()?;
+        let _: Token![_] = input.parse()?;
+        let contents;
+        braced!(contents in input);
         let mut rules = Vec::new();
-        while !input.is_empty() {
-            rules.push(input.parse()?)
+        while !contents.is_empty() {
+            rules.push(contents.parse()?)
         }
         Ok(Rules(rules))
     }

--- a/dhall_proc_macros/src/parser.rs
+++ b/dhall_proc_macros/src/parser.rs
@@ -1,0 +1,398 @@
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::parse::{Parse, ParseStream, Result};
+use syn::punctuated::Punctuated;
+use syn::{bracketed, parenthesized, token, Expr, Ident, Pat, Token, Type};
+
+mod rule_kw {
+    syn::custom_keyword!(rule);
+    syn::custom_keyword!(captured_str);
+    syn::custom_keyword!(children);
+    syn::custom_keyword!(prec_climb);
+}
+
+#[derive(Debug, Clone)]
+struct Rules(Vec<Rule>);
+
+#[derive(Debug, Clone)]
+struct Rule {
+    rule_token: rule_kw::rule,
+    bang_token: Token![!],
+    paren_token: token::Paren,
+    name: Ident,
+    lt_token: token::Lt,
+    output_type: Type,
+    gt_token: token::Gt,
+    contents: RuleContents,
+    semi_token: Token![;],
+}
+
+#[derive(Debug, Clone)]
+enum RuleContents {
+    Empty,
+    CapturedString {
+        span: Option<Ident>,
+        captured_str_token: rule_kw::captured_str,
+        bang_token: Token![!],
+        paren_token: token::Paren,
+        pattern: Pat,
+        fat_arrow_token: Token![=>],
+        body: Expr,
+    },
+    Children {
+        span: Option<Ident>,
+        children_token: rule_kw::children,
+        bang_token: Token![!],
+        paren_token: token::Paren,
+        branches: Punctuated<ChildrenBranch, Token![,]>,
+    },
+    PrecClimb {
+        span: Option<Ident>,
+        prec_climb_token: rule_kw::prec_climb,
+        bang_token: Token![!],
+        paren_token: token::Paren,
+        child_rule: Ident,
+        comma_token: Token![,],
+        climber: Expr,
+        comma_token2: Token![,],
+        pattern: Pat,
+        fat_arrow_token: Token![=>],
+        body: Expr,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct ChildrenBranch {
+    bracket_token: token::Bracket,
+    pattern_unparsed: TokenStream,
+    pattern: Punctuated<ChildrenBranchPatternItem, Token![,]>,
+    fat_arrow_token: Token![=>],
+    body: Expr,
+}
+
+#[derive(Debug, Clone)]
+enum ChildrenBranchPatternItem {
+    Single {
+        rule_name: Ident,
+        paren_token: token::Paren,
+        binder: Pat,
+    },
+    Multiple {
+        rule_name: Ident,
+        paren_token: token::Paren,
+        binder: Ident,
+        slice_token: Token![..],
+    },
+}
+
+impl Parse for Rules {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut rules = Vec::new();
+        while !input.is_empty() {
+            rules.push(input.parse()?)
+        }
+        Ok(Rules(rules))
+    }
+}
+
+impl Parse for Rule {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let contents;
+        Ok(Rule {
+            rule_token: input.parse()?,
+            bang_token: input.parse()?,
+            paren_token: parenthesized!(contents in input),
+            name: contents.parse()?,
+            lt_token: contents.parse()?,
+            output_type: contents.parse()?,
+            gt_token: contents.parse()?,
+            contents: contents.parse()?,
+            semi_token: input.parse()?,
+        })
+    }
+}
+
+impl Parse for RuleContents {
+    fn parse(input: ParseStream) -> Result<Self> {
+        if input.is_empty() {
+            return Ok(RuleContents::Empty);
+        }
+        let _: Token![;] = input.parse()?;
+        let span = if input.peek(Ident) && input.peek2(Token![;]) {
+            let span: Ident = input.parse()?;
+            let _: Token![;] = input.parse()?;
+            Some(span)
+        } else {
+            None
+        };
+
+        let lookahead = input.lookahead1();
+        if lookahead.peek(rule_kw::captured_str) {
+            let contents;
+            Ok(RuleContents::CapturedString {
+                span,
+                captured_str_token: input.parse()?,
+                bang_token: input.parse()?,
+                paren_token: parenthesized!(contents in input),
+                pattern: contents.parse()?,
+                fat_arrow_token: input.parse()?,
+                body: input.parse()?,
+            })
+        } else if lookahead.peek(rule_kw::children) {
+            let contents;
+            Ok(RuleContents::Children {
+                span,
+                children_token: input.parse()?,
+                bang_token: input.parse()?,
+                paren_token: parenthesized!(contents in input),
+                branches: Punctuated::parse_terminated(&contents)?,
+            })
+        } else if lookahead.peek(rule_kw::prec_climb) {
+            let contents;
+            Ok(RuleContents::PrecClimb {
+                span,
+                prec_climb_token: input.parse()?,
+                bang_token: input.parse()?,
+                paren_token: parenthesized!(contents in input),
+                child_rule: contents.parse()?,
+                comma_token: contents.parse()?,
+                climber: contents.parse()?,
+                comma_token2: contents.parse()?,
+                pattern: contents.parse()?,
+                fat_arrow_token: contents.parse()?,
+                body: contents.parse()?,
+            })
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+impl Parse for ChildrenBranch {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let contents;
+        Ok(ChildrenBranch {
+            bracket_token: bracketed!(contents in input),
+            pattern_unparsed: contents.fork().parse()?,
+            pattern: Punctuated::parse_terminated(&contents)?,
+            fat_arrow_token: input.parse()?,
+            body: input.parse()?,
+        })
+    }
+}
+
+impl Parse for ChildrenBranchPatternItem {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let rule_name = input.parse()?;
+        let contents;
+        let paren_token = parenthesized!(contents in input);
+        if input.peek(Token![..]) {
+            Ok(ChildrenBranchPatternItem::Multiple {
+                rule_name,
+                paren_token,
+                binder: contents.parse()?,
+                slice_token: input.parse()?,
+            })
+        } else if input.is_empty() || input.peek(Token![,]) {
+            Ok(ChildrenBranchPatternItem::Single {
+                rule_name,
+                paren_token,
+                binder: contents.parse()?,
+            })
+        } else {
+            Err(input.error("expected `..` or nothing"))
+        }
+    }
+}
+
+fn make_construct_precclimbers(rules: &Rules) -> Result<TokenStream> {
+    let mut entries: Vec<TokenStream> = Vec::new();
+    for rule in &rules.0 {
+        if let RuleContents::PrecClimb { climber, .. } = &rule.contents {
+            let name = &rule.name;
+            entries.push(quote!(
+                map.insert(Rule::#name, #climber);
+            ))
+        }
+    }
+
+    Ok(quote!(
+        fn construct_precclimbers() -> HashMap<Rule, PrecClimber<Rule>> {
+            let mut map = HashMap::new();
+            #(#entries)*
+            map
+        }
+    ))
+}
+
+fn make_entrypoints(rules: &Rules) -> Result<TokenStream> {
+    let mut entries: Vec<TokenStream> = Vec::new();
+    for rule in &rules.0 {
+        let name = &rule.name;
+        let output_type = &rule.output_type;
+        entries.push(quote!(
+            #[allow(non_snake_case, dead_code)]
+            fn #name<'a>(
+                input: Rc<str>,
+                pair: Pair<'a, Rule>,
+            ) -> ParseResult<#output_type> {
+                let climbers = construct_precclimbers();
+                Parsers::#name((&climbers, input), pair)
+            }
+        ))
+    }
+
+    Ok(quote!(
+        struct EntryPoint;
+        impl EntryPoint {
+            #(#entries)*
+        }
+    ))
+}
+
+fn make_parser_branch(branch: &ChildrenBranch) -> TokenStream {
+    let ChildrenBranch {
+        pattern,
+        body,
+        pattern_unparsed,
+        ..
+    } = branch;
+    let variable_pattern = Ident::new("variable_pattern", Span::call_site());
+    let match_pat = pattern.iter().map(|item| match item {
+        ChildrenBranchPatternItem::Single { rule_name, .. } => {
+            quote!(Rule::#rule_name)
+        }
+        ChildrenBranchPatternItem::Multiple { .. } => {
+            quote!(#variable_pattern..)
+        }
+    });
+    let match_filter = pattern.iter().map(|item| match item {
+        ChildrenBranchPatternItem::Single { .. } => quote!(true &&),
+        ChildrenBranchPatternItem::Multiple { rule_name, .. } => {
+            quote!(#variable_pattern.iter().all(|r| r == &Rule::#rule_name) &&)
+        }
+    });
+    quote!(
+        [#(#match_pat),*] if #(#match_filter)* true => {
+            parse_children!((climbers, input.clone()), iter;
+                [#pattern_unparsed] => {
+                    #[allow(unused_variables)]
+                    let res: Result<_, String> = try { #body };
+                    res.map_err(|msg|
+                        custom_parse_error(&pair, msg)
+                    )
+                }
+            )
+        }
+    )
+}
+
+fn make_parser_expr(rule: &Rule) -> Result<TokenStream> {
+    let name = &rule.name;
+    let expr = match &rule.contents {
+        RuleContents::Empty => quote!(Ok(())),
+        RuleContents::CapturedString { pattern, body, .. } => quote!(
+            let #pattern = pair.as_str();
+            let res: Result<_, String> = try { #body };
+            res.map_err(|msg| custom_parse_error(&pair, msg))
+        ),
+        RuleContents::PrecClimb {
+            child_rule,
+            pattern,
+            body,
+            ..
+        } => quote!(
+            let climber = climbers.get(&Rule::#name).unwrap();
+            climber.climb(
+                pair.clone().into_inner(),
+                |p| Parsers::#child_rule((climbers, input.clone()), p),
+                |l, op, r| {
+                    let #pattern = (l?, op, r?);
+                    let res: Result<_, String> = try { #body };
+                    res.map_err(|msg| custom_parse_error(&pair, msg))
+                },
+            )
+        ),
+        RuleContents::Children { branches, .. } => {
+            let branches = branches.iter().map(make_parser_branch);
+            quote!(
+                let children_rules: Vec<Rule> = pair
+                    .clone()
+                    .into_inner()
+                    .map(|p| p.as_rule())
+                    .collect();
+
+                #[allow(unused_mut)]
+                let mut iter = pair.clone().into_inner();
+
+                #[allow(unreachable_code)]
+                match children_rules.as_slice() {
+                    #(#branches,)*
+                    [..] => Err(custom_parse_error(
+                        &pair,
+                        format!("Unexpected children: {:?}", children_rules)
+                    )),
+                }
+            )
+        }
+    };
+    Ok(expr)
+}
+
+fn make_parsers(rules: &Rules) -> Result<TokenStream> {
+    let mut entries: Vec<TokenStream> = Vec::new();
+    for rule in &rules.0 {
+        let span_def = match &rule.contents {
+            RuleContents::CapturedString {
+                span: Some(span), ..
+            }
+            | RuleContents::Children {
+                span: Some(span), ..
+            }
+            | RuleContents::PrecClimb {
+                span: Some(span), ..
+            } => Some(quote!(
+                let #span = Span::make(input.clone(), pair.as_span());
+            )),
+            _ => None,
+        };
+
+        let name = &rule.name;
+        let output_type = &rule.output_type;
+        let expr = make_parser_expr(rule)?;
+
+        entries.push(quote!(
+            #[allow(non_snake_case, dead_code)]
+            fn #name<'a>(
+                (climbers, input): (&HashMap<Rule, PrecClimber<Rule>>, Rc<str>),
+                pair: Pair<'a, Rule>,
+            ) -> ParseResult<#output_type> {
+                #span_def
+                #expr
+            }
+        ))
+    }
+
+    Ok(quote!(
+        struct Parsers;
+        impl Parsers {
+            #(#entries)*
+        }
+    ))
+}
+
+pub fn make_parser(
+    input: proc_macro::TokenStream,
+) -> Result<proc_macro2::TokenStream> {
+    let rules: Rules = syn::parse_macro_input::parse(input.clone())?;
+
+    let construct_precclimbers = make_construct_precclimbers(&rules)?;
+    let entrypoints = make_entrypoints(&rules)?;
+    let parsers = make_parsers(&rules)?;
+
+    Ok(quote!(
+        #construct_precclimbers
+        #entrypoints
+        #parsers
+    ))
+}

--- a/dhall_syntax/Cargo.toml
+++ b/dhall_syntax/Cargo.toml
@@ -16,3 +16,4 @@ either = "1.5.2"
 take_mut = "0.2.2"
 hex = "0.3.2"
 dhall_generated_parser = { path = "../dhall_generated_parser" }
+dhall_proc_macros = { path = "../dhall_proc_macros" }

--- a/dhall_syntax/Cargo.toml
+++ b/dhall_syntax/Cargo.toml
@@ -15,5 +15,6 @@ pest = "2.1"
 either = "1.5.2"
 take_mut = "0.2.2"
 hex = "0.3.2"
+lazy_static = "1.4.0"
 dhall_generated_parser = { path = "../dhall_generated_parser" }
 dhall_proc_macros = { path = "../dhall_proc_macros" }

--- a/dhall_syntax/src/core/expr.rs
+++ b/dhall_syntax/src/core/expr.rs
@@ -381,15 +381,10 @@ pub fn rc<E>(x: RawExpr<E>) -> Expr<E> {
     Expr::from_expr_no_span(x)
 }
 
-pub(crate) fn spanned(
-    span: Span,
-    x: crate::parser::ParsedRawExpr,
-) -> crate::parser::ParsedExpr {
+pub(crate) fn spanned<E>(span: Span, x: RawExpr<E>) -> Expr<E> {
     Expr::new(x, span)
 }
-pub(crate) fn unspanned(
-    x: crate::parser::ParsedRawExpr,
-) -> crate::parser::ParsedExpr {
+pub(crate) fn unspanned<E>(x: RawExpr<E>) -> Expr<E> {
     Expr::from_expr_no_span(x)
 }
 

--- a/dhall_syntax/src/lib.rs
+++ b/dhall_syntax/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(try_blocks)]
 #![feature(never_type)]
 #![feature(bind_by_move_pattern_guards)]
+#![feature(proc_macro_hygiene)]
 #![allow(
     clippy::many_single_char_names,
     clippy::should_implement_trait,

--- a/dhall_syntax/src/lib.rs
+++ b/dhall_syntax/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(slice_patterns)]
 #![feature(try_blocks)]
 #![feature(never_type)]
-#![feature(bind_by_move_pattern_guards)]
 #![feature(proc_macro_hygiene)]
 #![allow(
     clippy::many_single_char_names,

--- a/dhall_syntax/src/lib.rs
+++ b/dhall_syntax/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(trace_macros)]
 #![feature(slice_patterns)]
-#![feature(try_blocks)]
 #![feature(never_type)]
 #![feature(proc_macro_hygiene)]
 #![feature(type_alias_enum_variants)]

--- a/dhall_syntax/src/lib.rs
+++ b/dhall_syntax/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(try_blocks)]
 #![feature(never_type)]
 #![feature(proc_macro_hygiene)]
+#![feature(type_alias_enum_variants)]
 #![allow(
     clippy::many_single_char_names,
     clippy::should_implement_trait,

--- a/dhall_syntax/src/parser.rs
+++ b/dhall_syntax/src/parser.rs
@@ -30,7 +30,7 @@ pub type ParseResult<T> = Result<T, ParseError>;
 #[derive(Debug, Clone)]
 struct ParseInput<'input, Rule>
 where
-    Rule: std::fmt::Debug + Copy + std::hash::Hash + Ord,
+    Rule: pest::RuleType,
 {
     pair: Pair<'input, Rule>,
     original_input_str: Rc<str>,
@@ -68,6 +68,11 @@ impl<'input> ParseInput<'input, Rule> {
     fn as_str(&self) -> &'input str {
         self.pair.as_str()
     }
+}
+
+// Used to retrieve the `Rule` enum associated with the `Self` type in `parse_children`.
+trait PestConsumer {
+    type RuleEnum: pest::RuleType;
 }
 
 fn debug_pair(pair: Pair<Rule>) -> String {
@@ -226,7 +231,7 @@ lazy_static::lazy_static! {
 
 struct Parsers;
 
-#[make_parser]
+#[make_parser(Rule)]
 impl Parsers {
     fn EOI(_: ParseInput<Rule>) -> ParseResult<()> {
         Ok(())

--- a/dhall_syntax/src/parser.rs
+++ b/dhall_syntax/src/parser.rs
@@ -224,8 +224,10 @@ lazy_static::lazy_static! {
     };
 }
 
+struct Parsers;
+
 #[make_parser]
-impl _ {
+impl Parsers {
     fn EOI(_: ParseInput<Rule>) -> ParseResult<()> {
         Ok(())
     }

--- a/dhall_syntax/src/parser.rs
+++ b/dhall_syntax/src/parser.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use dhall_generated_parser::{DhallParser, Rule};
+use dhall_proc_macros::{make_parser, parse_children};
 
 use crate::map::{DupTreeMap, DupTreeSet};
 use crate::ExprF::*;
@@ -26,6 +27,82 @@ type ParsedTextContents = InterpolatedTextContents<ParsedExpr>;
 pub type ParseError = pest::error::Error<Rule>;
 
 pub type ParseResult<T> = Result<T, ParseError>;
+
+#[derive(Debug, Clone)]
+struct ParseInput<'input, 'climbers, Rule>
+where
+    Rule: std::fmt::Debug + Copy + std::hash::Hash + Ord,
+{
+    pair: Pair<'input, Rule>,
+    climbers: &'climbers HashMap<Rule, PrecClimber<Rule>>,
+    original_input_str: Rc<str>,
+}
+
+impl<'input, 'climbers> ParseInput<'input, 'climbers, Rule> {
+    fn error(&self, message: String) -> ParseError {
+        let message = format!(
+            "{} while matching on:\n{}",
+            message,
+            debug_pair(self.pair.clone())
+        );
+        let e = pest::error::ErrorVariant::CustomError { message };
+        pest::error::Error::new_from_span(e, self.pair.as_span())
+    }
+    fn with_pair(&self, new_pair: Pair<'input, Rule>) -> Self {
+        ParseInput {
+            pair: new_pair,
+            climbers: self.climbers,
+            original_input_str: self.original_input_str.clone(),
+        }
+    }
+    fn as_span(&self) -> Span {
+        Span::make(self.original_input_str.clone(), self.pair.as_span())
+    }
+    fn as_str(&self) -> &'input str {
+        self.pair.as_str()
+    }
+}
+
+fn debug_pair(pair: Pair<Rule>) -> String {
+    use std::fmt::Write;
+    let mut s = String::new();
+    fn aux(s: &mut String, indent: usize, prefix: String, pair: Pair<Rule>) {
+        let indent_str = "| ".repeat(indent);
+        let rule = pair.as_rule();
+        let contents = pair.as_str();
+        let mut inner = pair.into_inner();
+        let mut first = true;
+        while let Some(p) = inner.next() {
+            if first {
+                first = false;
+                let last = inner.peek().is_none();
+                if last && p.as_str() == contents {
+                    let prefix = format!("{}{:?} > ", prefix, rule);
+                    aux(s, indent, prefix, p);
+                    continue;
+                } else {
+                    writeln!(
+                        s,
+                        r#"{}{}{:?}: "{}""#,
+                        indent_str, prefix, rule, contents
+                    )
+                    .unwrap();
+                }
+            }
+            aux(s, indent + 1, "".into(), p);
+        }
+        if first {
+            writeln!(
+                s,
+                r#"{}{}{:?}: "{}""#,
+                indent_str, prefix, rule, contents
+            )
+            .unwrap();
+        }
+    }
+    aux(&mut s, 0, "".into(), pair);
+    s
+}
 
 #[derive(Debug)]
 enum Either<A, B> {
@@ -71,124 +148,6 @@ impl crate::Builtin {
     }
 }
 
-pub fn custom_parse_error(pair: &Pair<Rule>, msg: String) -> ParseError {
-    let msg =
-        format!("{} while matching on:\n{}", msg, debug_pair(pair.clone()));
-    let e = pest::error::ErrorVariant::CustomError { message: msg };
-    pest::error::Error::new_from_span(e, pair.as_span())
-}
-
-fn debug_pair(pair: Pair<Rule>) -> String {
-    use std::fmt::Write;
-    let mut s = String::new();
-    fn aux(s: &mut String, indent: usize, prefix: String, pair: Pair<Rule>) {
-        let indent_str = "| ".repeat(indent);
-        let rule = pair.as_rule();
-        let contents = pair.as_str();
-        let mut inner = pair.into_inner();
-        let mut first = true;
-        while let Some(p) = inner.next() {
-            if first {
-                first = false;
-                let last = inner.peek().is_none();
-                if last && p.as_str() == contents {
-                    let prefix = format!("{}{:?} > ", prefix, rule);
-                    aux(s, indent, prefix, p);
-                    continue;
-                } else {
-                    writeln!(
-                        s,
-                        r#"{}{}{:?}: "{}""#,
-                        indent_str, prefix, rule, contents
-                    )
-                    .unwrap();
-                }
-            }
-            aux(s, indent + 1, "".into(), p);
-        }
-        if first {
-            writeln!(
-                s,
-                r#"{}{}{:?}: "{}""#,
-                indent_str, prefix, rule, contents
-            )
-            .unwrap();
-        }
-    }
-    aux(&mut s, 0, "".into(), pair);
-    s
-}
-
-macro_rules! parse_children {
-    // Variable length pattern with a common unary variant
-    (@match_forwards,
-        $parse_args:expr,
-        $iter:expr,
-        ($body:expr),
-        $variant:ident ($x:ident)..,
-        $($rest:tt)*
-    ) => {
-        parse_children!(@match_backwards,
-            $parse_args, $iter,
-            ({
-                let $x = $iter
-                    .map(|x| Parsers::$variant($parse_args, x))
-                    .collect::<Result<Vec<_>, _>>()?
-                    .into_iter();
-                $body
-            }),
-            $($rest)*
-        )
-    };
-    // Single item pattern
-    (@match_forwards,
-        $parse_args:expr,
-        $iter:expr,
-        ($body:expr),
-        $variant:ident ($x:pat),
-        $($rest:tt)*
-    ) => {{
-        let p = $iter.next().unwrap();
-        let $x = Parsers::$variant($parse_args, p)?;
-        parse_children!(@match_forwards,
-            $parse_args, $iter,
-            ($body),
-            $($rest)*
-        )
-    }};
-    // Single item pattern after a variable length one: declare reversed and take from the end
-    (@match_backwards,
-        $parse_args:expr,
-        $iter:expr,
-        ($body:expr),
-        $variant:ident ($x:pat),
-        $($rest:tt)*
-    ) => {
-        parse_children!(@match_backwards, $parse_args, $iter, ({
-            let p = $iter.next_back().unwrap();
-            let $x = Parsers::$variant($parse_args, p)?;
-            $body
-        }), $($rest)*)
-    };
-
-    // Check no elements remain
-    (@match_forwards, $parse_args:expr, $iter:expr, ($body:expr) $(,)*) => {
-        $body
-    };
-    // After a variable length pattern, everything has already been consumed
-    (@match_backwards, $parse_args:expr, $iter:expr, ($body:expr) $(,)*) => {
-        $body
-    };
-
-    ($parse_args:expr, $iter:expr; [$($args:tt)*] => $body:expr) => {
-        parse_children!(@match_forwards,
-            $parse_args, $iter,
-            ($body),
-            $($args)*,
-        )
-    };
-}
-
 // Trim the shared indent off of a vec of lines, as defined by the Dhall semantics of multiline
 // literals.
 fn trim_indent(lines: &mut Vec<ParsedText>) {
@@ -230,674 +189,894 @@ fn trim_indent(lines: &mut Vec<ParsedText>) {
     }
 }
 
-dhall_proc_macros::make_parser! {
-    rule!(EOI<()>);
+fn make_precclimber() -> PrecClimber<Rule> {
+    use Rule::*;
+    // In order of precedence
+    let operators = vec![
+        import_alt,
+        bool_or,
+        natural_plus,
+        text_append,
+        list_append,
+        bool_and,
+        combine,
+        prefer,
+        combine_types,
+        natural_times,
+        bool_eq,
+        bool_ne,
+        equivalent,
+    ];
+    PrecClimber::new(
+        operators
+            .into_iter()
+            .map(|op| pcl::Operator::new(op, pcl::Assoc::Left))
+            .collect(),
+    )
+}
 
-    rule!(simple_label<Label>;
-        captured_str!(s) => Label::from(s.trim().to_owned())
-    );
-    rule!(quoted_label<Label>;
-        captured_str!(s) => Label::from(s.trim().to_owned())
-    );
-    rule!(label<Label>; children!(
-        [simple_label(l)] => l,
-        [quoted_label(l)] => l,
-    ));
+make_parser! {
+    fn EOI(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
 
-    rule!(double_quote_literal<ParsedText>; children!(
-        [double_quote_chunk(chunks)..] => {
-            chunks.collect()
-        }
-    ));
+    fn simple_label(input: ParseInput<Rule>) -> ParseResult<Label> {
+        Ok(Label::from(input.as_str().trim().to_owned()))
+    }
+    fn quoted_label(input: ParseInput<Rule>) -> ParseResult<Label> {
+        Ok(Label::from(input.as_str().trim().to_owned()))
+    }
+    fn label(input: ParseInput<Rule>) -> ParseResult<Label> {
+        Ok(parse_children!(input;
+            [simple_label(l)] => l,
+            [quoted_label(l)] => l,
+        ))
+    }
 
-    rule!(double_quote_chunk<ParsedTextContents>; children!(
-        [interpolation(e)] => {
-            InterpolatedTextContents::Expr(e)
-        },
-        [double_quote_escaped(s)] => {
-            InterpolatedTextContents::Text(s)
-        },
-        [double_quote_char(s)] => {
-            InterpolatedTextContents::Text(s.to_owned())
-        },
-    ));
-    rule!(double_quote_escaped<String>;
-        captured_str!(s) => {
-            match s {
-                "\"" => "\"".to_owned(),
-                "$" => "$".to_owned(),
-                "\\" => "\\".to_owned(),
-                "/" => "/".to_owned(),
-                "b" => "\u{0008}".to_owned(),
-                "f" => "\u{000C}".to_owned(),
-                "n" => "\n".to_owned(),
-                "r" => "\r".to_owned(),
-                "t" => "\t".to_owned(),
-                // "uXXXX" or "u{XXXXX}"
-                _ => {
-                    use std::convert::{TryFrom, TryInto};
-
-                    let s = &s[1..];
-                    let s = if &s[0..1] == "{" {
-                        &s[1..s.len()-1]
-                    } else {
-                        &s[0..s.len()]
-                    };
-
-                    if s.len() > 8 {
-                        Err(format!("Escape sequences can't have more than 8 chars: \"{}\"", s))?
-                    }
-
-                    // pad with zeroes
-                    let s: String = std::iter::repeat('0')
-                        .take(8 - s.len())
-                        .chain(s.chars())
-                        .collect();
-
-                    // `s` has length 8, so `bytes` has length 4
-                    let bytes: &[u8] = &hex::decode(s).unwrap();
-                    let i = u32::from_be_bytes(bytes.try_into().unwrap());
-                    let c = char::try_from(i).unwrap();
-                    match i {
-                        0xD800..=0xDFFF => {
-                            let c_ecapsed = c.escape_unicode();
-                            Err(format!("Escape sequences can't contain surrogate pairs: \"{}\"", c_ecapsed))?
-                        },
-                        0x0FFFE..=0x0FFFF | 0x1FFFE..=0x1FFFF |
-                        0x2FFFE..=0x2FFFF | 0x3FFFE..=0x3FFFF |
-                        0x4FFFE..=0x4FFFF | 0x5FFFE..=0x5FFFF |
-                        0x6FFFE..=0x6FFFF | 0x7FFFE..=0x7FFFF |
-                        0x8FFFE..=0x8FFFF | 0x9FFFE..=0x9FFFF |
-                        0xAFFFE..=0xAFFFF | 0xBFFFE..=0xBFFFF |
-                        0xCFFFE..=0xCFFFF | 0xDFFFE..=0xDFFFF |
-                        0xEFFFE..=0xEFFFF | 0xFFFFE..=0xFFFFF |
-                        0x10_FFFE..=0x10_FFFF => {
-                            let c_ecapsed = c.escape_unicode();
-                            Err(format!("Escape sequences can't contain non-characters: \"{}\"", c_ecapsed))?
-                        },
-                        _ => {}
-                    }
-                    std::iter::once(c).collect()
-                }
+    fn double_quote_literal(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<ParsedText> {
+        Ok(parse_children!(input;
+            [double_quote_chunk(chunks)..] => {
+                chunks.collect()
             }
-        }
-    );
-    rule!(double_quote_char<&'a str>;
-        captured_str!(s) => s
-    );
+        ))
+    }
 
-    rule!(single_quote_literal<ParsedText>; children!(
-        [single_quote_continue(lines)] => {
-            let newline: ParsedText = "\n".to_string().into();
+    fn double_quote_chunk(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<ParsedTextContents> {
+        Ok(parse_children!(input;
+            [interpolation(e)] => {
+                InterpolatedTextContents::Expr(e)
+            },
+            [double_quote_escaped(s)] => {
+                InterpolatedTextContents::Text(s)
+            },
+            [double_quote_char(s)] => {
+                InterpolatedTextContents::Text(s.to_owned())
+            },
+        ))
+    }
+    fn double_quote_escaped(input: ParseInput<Rule>) -> ParseResult<String> {
+        Ok(match input.as_str() {
+            "\"" => "\"".to_owned(),
+            "$" => "$".to_owned(),
+            "\\" => "\\".to_owned(),
+            "/" => "/".to_owned(),
+            "b" => "\u{0008}".to_owned(),
+            "f" => "\u{000C}".to_owned(),
+            "n" => "\n".to_owned(),
+            "r" => "\r".to_owned(),
+            "t" => "\t".to_owned(),
+            // "uXXXX" or "u{XXXXX}"
+            s => {
+                use std::convert::{TryFrom, TryInto};
 
-            let mut lines: Vec<ParsedText> = lines
-                .into_iter()
-                .rev()
-                .map(|l| l.into_iter().rev().collect::<ParsedText>())
-                .collect();
+                let s = &s[1..];
+                let s = if &s[0..1] == "{" {
+                    &s[1..s.len() - 1]
+                } else {
+                    &s[0..s.len()]
+                };
 
-            trim_indent(&mut lines);
+                if s.len() > 8 {
+                    Err(input.error(format!(
+                        "Escape sequences can't have more than 8 chars: \"{}\"",
+                        s
+                    )))?
+                }
 
-            lines
-                .into_iter()
-                .intersperse(newline)
-                .flat_map(InterpolatedText::into_iter)
-                .collect::<ParsedText>()
-        }
-    ));
-    rule!(single_quote_char<&'a str>;
-        captured_str!(s) => s
-    );
-    rule!(escaped_quote_pair<&'a str>;
-        captured_str!(_) => "''"
-    );
-    rule!(escaped_interpolation<&'a str>;
-        captured_str!(_) => "${"
-    );
-    rule!(interpolation<ParsedExpr>; children!(
-        [expression(e)] => e
-    ));
+                // pad with zeroes
+                let s: String = std::iter::repeat('0')
+                    .take(8 - s.len())
+                    .chain(s.chars())
+                    .collect();
+
+                // `s` has length 8, so `bytes` has length 4
+                let bytes: &[u8] = &hex::decode(s).unwrap();
+                let i = u32::from_be_bytes(bytes.try_into().unwrap());
+                let c = char::try_from(i).unwrap();
+                match i {
+                    0xD800..=0xDFFF => {
+                        let c_ecapsed = c.escape_unicode();
+                        Err(input.error(format!("Escape sequences can't contain surrogate pairs: \"{}\"", c_ecapsed)))?
+                    }
+                    0x0FFFE..=0x0FFFF
+                    | 0x1FFFE..=0x1FFFF
+                    | 0x2FFFE..=0x2FFFF
+                    | 0x3FFFE..=0x3FFFF
+                    | 0x4FFFE..=0x4FFFF
+                    | 0x5FFFE..=0x5FFFF
+                    | 0x6FFFE..=0x6FFFF
+                    | 0x7FFFE..=0x7FFFF
+                    | 0x8FFFE..=0x8FFFF
+                    | 0x9FFFE..=0x9FFFF
+                    | 0xAFFFE..=0xAFFFF
+                    | 0xBFFFE..=0xBFFFF
+                    | 0xCFFFE..=0xCFFFF
+                    | 0xDFFFE..=0xDFFFF
+                    | 0xEFFFE..=0xEFFFF
+                    | 0xFFFFE..=0xFFFFF
+                    | 0x10_FFFE..=0x10_FFFF => {
+                        let c_ecapsed = c.escape_unicode();
+                        Err(input.error(format!("Escape sequences can't contain non-characters: \"{}\"", c_ecapsed)))?
+                    }
+                    _ => {}
+                }
+                std::iter::once(c).collect()
+            }
+        })
+    }
+    fn double_quote_char<'a>(
+        input: ParseInput<'a, '_, Rule>,
+    ) -> ParseResult<&'a str> {
+        Ok(input.as_str())
+    }
+
+    fn single_quote_literal(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<ParsedText> {
+        Ok(parse_children!(input;
+            [single_quote_continue(lines)] => {
+                let newline: ParsedText = "\n".to_string().into();
+
+                let mut lines: Vec<ParsedText> = lines
+                    .into_iter()
+                    .rev()
+                    .map(|l| l.into_iter().rev().collect::<ParsedText>())
+                    .collect();
+
+                trim_indent(&mut lines);
+
+                lines
+                    .into_iter()
+                    .intersperse(newline)
+                    .flat_map(InterpolatedText::into_iter)
+                    .collect::<ParsedText>()
+            }
+        ))
+    }
+    fn single_quote_char<'a>(
+        input: ParseInput<'a, '_, Rule>,
+    ) -> ParseResult<&'a str> {
+        Ok(input.as_str())
+    }
+    fn escaped_quote_pair<'a>(
+        _: ParseInput<'a, '_, Rule>,
+    ) -> ParseResult<&'a str> {
+        Ok("''")
+    }
+    fn escaped_interpolation<'a>(
+        _: ParseInput<'a, '_, Rule>,
+    ) -> ParseResult<&'a str> {
+        Ok("${")
+    }
+    fn interpolation(input: ParseInput<Rule>) -> ParseResult<ParsedExpr> {
+        Ok(parse_children!(input;
+            [expression(e)] => e
+        ))
+    }
 
     // Returns a vec of lines in reversed order, where each line is also in reversed order.
-    rule!(single_quote_continue<Vec<Vec<ParsedTextContents>>>; children!(
-        [interpolation(c), single_quote_continue(lines)] => {
-            let c = InterpolatedTextContents::Expr(c);
-            let mut lines = lines;
-            lines.last_mut().unwrap().push(c);
-            lines
-        },
-        [escaped_quote_pair(c), single_quote_continue(lines)] => {
-            let mut lines = lines;
-            // TODO: don't allocate for every char
-            let c = InterpolatedTextContents::Text(c.to_owned());
-            lines.last_mut().unwrap().push(c);
-            lines
-        },
-        [escaped_interpolation(c), single_quote_continue(lines)] => {
-            let mut lines = lines;
-            // TODO: don't allocate for every char
-            let c = InterpolatedTextContents::Text(c.to_owned());
-            lines.last_mut().unwrap().push(c);
-            lines
-        },
-        [single_quote_char(c), single_quote_continue(lines)] => {
-            let mut lines = lines;
-            if c == "\n" || c == "\r\n" {
-                lines.push(vec![]);
-            } else {
+    fn single_quote_continue(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<Vec<Vec<ParsedTextContents>>> {
+        Ok(parse_children!(input;
+            [interpolation(c), single_quote_continue(lines)] => {
+                let c = InterpolatedTextContents::Expr(c);
+                let mut lines = lines;
+                lines.last_mut().unwrap().push(c);
+                lines
+            },
+            [escaped_quote_pair(c), single_quote_continue(lines)] => {
+                let mut lines = lines;
                 // TODO: don't allocate for every char
                 let c = InterpolatedTextContents::Text(c.to_owned());
                 lines.last_mut().unwrap().push(c);
-            }
-            lines
-        },
-        [] => {
-            vec![vec![]]
-        },
-    ));
-
-    rule!(builtin<ParsedExpr>; span;
-        captured_str!(s) => {
-            spanned(span, match crate::Builtin::parse(s) {
-                Some(b) => Builtin(b),
-                None => match s {
-                    "True" => BoolLit(true),
-                    "False" => BoolLit(false),
-                    "Type" => Const(crate::Const::Type),
-                    "Kind" => Const(crate::Const::Kind),
-                    "Sort" => Const(crate::Const::Sort),
-                    _ => Err(
-                        format!("Unrecognized builtin: '{}'", s)
-                    )?,
+                lines
+            },
+            [escaped_interpolation(c), single_quote_continue(lines)] => {
+                let mut lines = lines;
+                // TODO: don't allocate for every char
+                let c = InterpolatedTextContents::Text(c.to_owned());
+                lines.last_mut().unwrap().push(c);
+                lines
+            },
+            [single_quote_char(c), single_quote_continue(lines)] => {
+                let mut lines = lines;
+                if c == "\n" || c == "\r\n" {
+                    lines.push(vec![]);
+                } else {
+                    // TODO: don't allocate for every char
+                    let c = InterpolatedTextContents::Text(c.to_owned());
+                    lines.last_mut().unwrap().push(c);
                 }
-            })
-        }
-    );
+                lines
+            },
+            [] => {
+                vec![vec![]]
+            },
+        ))
+    }
 
-    rule!(NaN<()>);
-    rule!(minus_infinity_literal<()>);
-    rule!(plus_infinity_literal<()>);
-
-    rule!(numeric_double_literal<core::Double>;
-        captured_str!(s) => {
-            let s = s.trim();
-            match s.parse::<f64>() {
-                Ok(x) if x.is_infinite() =>
-                    Err(format!("Overflow while parsing double literal '{}'", s))?,
-                Ok(x) => NaiveDouble::from(x),
-                Err(e) => Err(format!("{}", e))?,
-            }
-        }
-    );
-
-    rule!(double_literal<core::Double>; children!(
-        [numeric_double_literal(n)] => n,
-        [minus_infinity_literal(_)] => std::f64::NEG_INFINITY.into(),
-        [plus_infinity_literal(_)] => std::f64::INFINITY.into(),
-        [NaN(_)] => std::f64::NAN.into(),
-    ));
-
-    rule!(natural_literal<core::Natural>;
-        captured_str!(s) => {
-            s.trim()
-                .parse()
-                .map_err(|e| format!("{}", e))?
-        }
-    );
-
-    rule!(integer_literal<core::Integer>;
-        captured_str!(s) => {
-            s.trim()
-                .parse()
-                .map_err(|e| format!("{}", e))?
-        }
-    );
-
-    rule!(identifier<ParsedExpr>; span; children!(
-        [variable(v)] => {
-            spanned(span, Var(v))
-        },
-        [builtin(e)] => e,
-    ));
-
-    rule!(variable<V<Label>>; children!(
-        [label(l), natural_literal(idx)] => {
-            V(l, idx)
-        },
-        [label(l)] => {
-            V(l, 0)
-        },
-    ));
-
-    rule!(unquoted_path_component<&'a str>; captured_str!(s) => s);
-    rule!(quoted_path_component<&'a str>; captured_str!(s) => s);
-    rule!(path_component<String>; children!(
-        [unquoted_path_component(s)] => s.to_string(),
-        [quoted_path_component(s)] => {
-            const RESERVED: &percent_encoding::AsciiSet =
-                &percent_encoding::CONTROLS
-                .add(b'=').add(b':').add(b'/').add(b'?')
-                .add(b'#').add(b'[').add(b']').add(b'@')
-                .add(b'!').add(b'$').add(b'&').add(b'\'')
-                .add(b'(').add(b')').add(b'*').add(b'+')
-                .add(b',').add(b';');
-            s.chars()
-                .map(|c| {
-                    // Percent-encode ascii chars
-                    if c.is_ascii() {
-                        percent_encoding::utf8_percent_encode(
-                            &c.to_string(),
-                            RESERVED,
-                        ).to_string()
-                    } else {
-                        c.to_string()
+    fn builtin(input: ParseInput<Rule>) -> ParseResult<ParsedExpr> {
+        let s = input.as_str();
+        let span = input.as_span();
+        Ok(spanned(
+            span,
+            match crate::Builtin::parse(s) {
+                Some(b) => Builtin(b),
+                None => {
+                    match s {
+                        "True" => BoolLit(true),
+                        "False" => BoolLit(false),
+                        "Type" => Const(crate::Const::Type),
+                        "Kind" => Const(crate::Const::Kind),
+                        "Sort" => Const(crate::Const::Sort),
+                        _ => Err(input
+                            .error(format!("Unrecognized builtin: '{}'", s)))?,
                     }
-                })
-                .collect()
-        },
-    ));
-    rule!(path<Vec<String>>; children!(
-        [path_component(components)..] => {
-            components.collect()
+                }
+            },
+        ))
+    }
+
+    fn NaN(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+    fn minus_infinity_literal(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+    fn plus_infinity_literal(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+
+    fn numeric_double_literal(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<core::Double> {
+        let s = input.as_str().trim();
+        match s.parse::<f64>() {
+            Ok(x) if x.is_infinite() => Err(input.error(format!(
+                "Overflow while parsing double literal '{}'",
+                s
+            ))),
+            Ok(x) => Ok(NaiveDouble::from(x)),
+            Err(e) => Err(input.error(format!("{}", e))),
         }
-    ));
+    }
 
-    rule!(local<(FilePrefix, Vec<String>)>; children!(
-        [parent_path(l)] => l,
-        [here_path(l)] => l,
-        [home_path(l)] => l,
-        [absolute_path(l)] => l,
-    ));
+    fn double_literal(input: ParseInput<Rule>) -> ParseResult<core::Double> {
+        Ok(parse_children!(input;
+            [numeric_double_literal(n)] => n,
+            [minus_infinity_literal(_)] => std::f64::NEG_INFINITY.into(),
+            [plus_infinity_literal(_)] => std::f64::INFINITY.into(),
+            [NaN(_)] => std::f64::NAN.into(),
+        ))
+    }
 
-    rule!(parent_path<(FilePrefix, Vec<String>)>; children!(
-        [path(p)] => (FilePrefix::Parent, p)
-    ));
-    rule!(here_path<(FilePrefix, Vec<String>)>; children!(
-        [path(p)] => (FilePrefix::Here, p)
-    ));
-    rule!(home_path<(FilePrefix, Vec<String>)>; children!(
-        [path(p)] => (FilePrefix::Home, p)
-    ));
-    rule!(absolute_path<(FilePrefix, Vec<String>)>; children!(
-        [path(p)] => (FilePrefix::Absolute, p)
-    ));
+    fn natural_literal(input: ParseInput<Rule>) -> ParseResult<core::Natural> {
+        input
+            .as_str()
+            .trim()
+            .parse()
+            .map_err(|e| input.error(format!("{}", e)))
+    }
 
-    rule!(scheme<Scheme>; captured_str!(s) => match s {
-        "http" => Scheme::HTTP,
-        "https" => Scheme::HTTPS,
-        _ => unreachable!(),
-    });
+    fn integer_literal(input: ParseInput<Rule>) -> ParseResult<core::Integer> {
+        input
+            .as_str()
+            .trim()
+            .parse()
+            .map_err(|e| input.error(format!("{}", e)))
+    }
 
-    rule!(http_raw<URL<ParsedExpr>>; children!(
-        [scheme(sch), authority(auth), path(p)] => URL {
-            scheme: sch,
-            authority: auth,
-            path: p,
-            query: None,
-            headers: None,
-        },
-        [scheme(sch), authority(auth), path(p), query(q)] => URL {
-            scheme: sch,
-            authority: auth,
-            path: p,
-            query: Some(q),
-            headers: None,
-        },
-    ));
+    fn identifier(input: ParseInput<Rule>) -> ParseResult<ParsedExpr> {
+        let span = input.as_span();
+        Ok(parse_children!(input;
+            [variable(v)] => {
+                spanned(span, Var(v))
+            },
+            [builtin(e)] => e,
+        ))
+    }
 
-    rule!(authority<String>; captured_str!(s) => s.to_owned());
+    fn variable(input: ParseInput<Rule>) -> ParseResult<V<Label>> {
+        Ok(parse_children!(input;
+            [label(l), natural_literal(idx)] => {
+                V(l, idx)
+            },
+            [label(l)] => {
+                V(l, 0)
+            },
+        ))
+    }
 
-    rule!(query<String>; captured_str!(s) => s.to_owned());
+    fn unquoted_path_component<'a>(
+        input: ParseInput<'a, '_, Rule>,
+    ) -> ParseResult<&'a str> {
+        Ok(input.as_str())
+    }
+    fn quoted_path_component<'a>(
+        input: ParseInput<'a, '_, Rule>,
+    ) -> ParseResult<&'a str> {
+        Ok(input.as_str())
+    }
+    fn path_component(input: ParseInput<Rule>) -> ParseResult<String> {
+        Ok(parse_children!(input;
+            [unquoted_path_component(s)] => s.to_string(),
+            [quoted_path_component(s)] => {
+                const RESERVED: &percent_encoding::AsciiSet =
+                    &percent_encoding::CONTROLS
+                    .add(b'=').add(b':').add(b'/').add(b'?')
+                    .add(b'#').add(b'[').add(b']').add(b'@')
+                    .add(b'!').add(b'$').add(b'&').add(b'\'')
+                    .add(b'(').add(b')').add(b'*').add(b'+')
+                    .add(b',').add(b';');
+                s.chars()
+                    .map(|c| {
+                        // Percent-encode ascii chars
+                        if c.is_ascii() {
+                            percent_encoding::utf8_percent_encode(
+                                &c.to_string(),
+                                RESERVED,
+                            ).to_string()
+                        } else {
+                            c.to_string()
+                        }
+                    })
+                    .collect()
+            },
+        ))
+    }
+    fn path(input: ParseInput<Rule>) -> ParseResult<Vec<String>> {
+        Ok(parse_children!(input;
+            [path_component(components)..] => {
+                components.collect()
+            }
+        ))
+    }
 
-    rule!(http<URL<ParsedExpr>>; children!(
+    fn local(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<(FilePrefix, Vec<String>)> {
+        Ok(parse_children!(input;
+            [parent_path(l)] => l,
+            [here_path(l)] => l,
+            [home_path(l)] => l,
+            [absolute_path(l)] => l,
+        ))
+    }
+
+    fn parent_path(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<(FilePrefix, Vec<String>)> {
+        Ok(parse_children!(input;
+            [path(p)] => (FilePrefix::Parent, p)
+        ))
+    }
+    fn here_path(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<(FilePrefix, Vec<String>)> {
+        Ok(parse_children!(input;
+            [path(p)] => (FilePrefix::Here, p)
+        ))
+    }
+    fn home_path(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<(FilePrefix, Vec<String>)> {
+        Ok(parse_children!(input;
+            [path(p)] => (FilePrefix::Home, p)
+        ))
+    }
+    fn absolute_path(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<(FilePrefix, Vec<String>)> {
+        Ok(parse_children!(input;
+            [path(p)] => (FilePrefix::Absolute, p)
+        ))
+    }
+
+    fn scheme(input: ParseInput<Rule>) -> ParseResult<Scheme> {
+        Ok(match input.as_str() {
+            "http" => Scheme::HTTP,
+            "https" => Scheme::HTTPS,
+            _ => unreachable!(),
+        })
+    }
+
+    fn http_raw(input: ParseInput<Rule>) -> ParseResult<URL<ParsedExpr>> {
+        Ok(parse_children!(input;
+            [scheme(sch), authority(auth), path(p)] => URL {
+                scheme: sch,
+                authority: auth,
+                path: p,
+                query: None,
+                headers: None,
+            },
+            [scheme(sch), authority(auth), path(p), query(q)] => URL {
+                scheme: sch,
+                authority: auth,
+                path: p,
+                query: Some(q),
+                headers: None,
+            },
+        ))
+    }
+
+    fn authority(input: ParseInput<Rule>) -> ParseResult<String> {
+        Ok(input.as_str().to_owned())
+    }
+
+    fn query(input: ParseInput<Rule>) -> ParseResult<String> {
+        Ok(input.as_str().to_owned())
+    }
+
+    fn http(input: ParseInput<Rule>) -> ParseResult<URL<ParsedExpr>> {
+        Ok(parse_children!(input;
         [http_raw(url)] => url,
         [http_raw(url), import_expression(e)] =>
             URL { headers: Some(e), ..url },
-    ));
+        ))
+    }
 
-    rule!(env<String>; children!(
-        [bash_environment_variable(s)] => s,
-        [posix_environment_variable(s)] => s,
-    ));
-    rule!(bash_environment_variable<String>; captured_str!(s) => s.to_owned());
-    rule!(posix_environment_variable<String>; children!(
-        [posix_environment_variable_character(chars)..] => {
-            chars.collect()
-        },
-    ));
-    rule!(posix_environment_variable_character<Cow<'a, str>>;
-        captured_str!(s) => {
-            match s {
-                "\\\"" => Cow::Owned("\"".to_owned()),
-                "\\\\" => Cow::Owned("\\".to_owned()),
-                "\\a" =>  Cow::Owned("\u{0007}".to_owned()),
-                "\\b" =>  Cow::Owned("\u{0008}".to_owned()),
-                "\\f" =>  Cow::Owned("\u{000C}".to_owned()),
-                "\\n" =>  Cow::Owned("\n".to_owned()),
-                "\\r" =>  Cow::Owned("\r".to_owned()),
-                "\\t" =>  Cow::Owned("\t".to_owned()),
-                "\\v" =>  Cow::Owned("\u{000B}".to_owned()),
-                _ => Cow::Borrowed(s)
-            }
-        }
-    );
+    fn env(input: ParseInput<Rule>) -> ParseResult<String> {
+        Ok(parse_children!(input;
+            [bash_environment_variable(s)] => s,
+            [posix_environment_variable(s)] => s,
+        ))
+    }
+    fn bash_environment_variable(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<String> {
+        Ok(input.as_str().to_owned())
+    }
+    fn posix_environment_variable(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<String> {
+        Ok(parse_children!(input;
+            [posix_environment_variable_character(chars)..] => {
+                chars.collect()
+            },
+        ))
+    }
+    fn posix_environment_variable_character<'a>(
+        input: ParseInput<'a, '_, Rule>,
+    ) -> ParseResult<Cow<'a, str>> {
+        Ok(match input.as_str() {
+            "\\\"" => Cow::Owned("\"".to_owned()),
+            "\\\\" => Cow::Owned("\\".to_owned()),
+            "\\a" => Cow::Owned("\u{0007}".to_owned()),
+            "\\b" => Cow::Owned("\u{0008}".to_owned()),
+            "\\f" => Cow::Owned("\u{000C}".to_owned()),
+            "\\n" => Cow::Owned("\n".to_owned()),
+            "\\r" => Cow::Owned("\r".to_owned()),
+            "\\t" => Cow::Owned("\t".to_owned()),
+            "\\v" => Cow::Owned("\u{000B}".to_owned()),
+            s => Cow::Borrowed(s),
+        })
+    }
 
-    rule!(missing<()>);
+    fn missing(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
 
-    rule!(import_type<ImportLocation<ParsedExpr>>; children!(
-        [missing(_)] => {
-            ImportLocation::Missing
-        },
-        [env(e)] => {
-            ImportLocation::Env(e)
-        },
-        [http(url)] => {
-            ImportLocation::Remote(url)
-        },
-        [local((prefix, p))] => {
-            ImportLocation::Local(prefix, p)
-        },
-    ));
+    fn import_type(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<ImportLocation<ParsedExpr>> {
+        Ok(parse_children!(input;
+            [missing(_)] => {
+                ImportLocation::Missing
+            },
+            [env(e)] => {
+                ImportLocation::Env(e)
+            },
+            [http(url)] => {
+                ImportLocation::Remote(url)
+            },
+            [local((prefix, p))] => {
+                ImportLocation::Local(prefix, p)
+            },
+        ))
+    }
 
-    rule!(hash<Hash>; captured_str!(s) => {
-        let s = s.trim();
+    fn hash(input: ParseInput<Rule>) -> ParseResult<Hash> {
+        let s = input.as_str().trim();
         let protocol = &s[..6];
         let hash = &s[7..];
         if protocol != "sha256" {
-            Err(format!("Unknown hashing protocol '{}'", protocol))?
+            Err(input.error(format!("Unknown hashing protocol '{}'", protocol)))?
         }
-        Hash::SHA256(hex::decode(hash).unwrap())
-    });
+        Ok(Hash::SHA256(hex::decode(hash).unwrap()))
+    }
 
-    rule!(import_hashed<crate::Import<ParsedExpr>>; children!(
+    fn import_hashed(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<crate::Import<ParsedExpr>> {
+        Ok(parse_children!(input;
         [import_type(location)] =>
             crate::Import {mode: ImportMode::Code, location, hash: None },
         [import_type(location), hash(h)] =>
-            crate::Import {mode: ImportMode::Code, location, hash: Some(h) },
-    ));
+        crate::Import {mode: ImportMode::Code, location, hash: Some(h) },
+        ))
+    }
 
-    rule!(Text<()>);
-    rule!(Location<()>);
+    fn Text(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+    fn Location(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
 
-    rule!(import<ParsedExpr>; span; children!(
-        [import_hashed(imp)] => {
-            spanned(span, Import(crate::Import {
-                mode: ImportMode::Code,
-                ..imp
-            }))
-        },
-        [import_hashed(imp), Text(_)] => {
-            spanned(span, Import(crate::Import {
-                mode: ImportMode::RawText,
-                ..imp
-            }))
-        },
-        [import_hashed(imp), Location(_)] => {
-            spanned(span, Import(crate::Import {
-                mode: ImportMode::Location,
-                ..imp
-            }))
-        },
-    ));
+    fn import(input: ParseInput<Rule>) -> ParseResult<ParsedExpr> {
+        let span = input.as_span();
+        Ok(parse_children!(input;
+            [import_hashed(imp)] => {
+                spanned(span, Import(crate::Import {
+                    mode: ImportMode::Code,
+                    ..imp
+                }))
+            },
+            [import_hashed(imp), Text(_)] => {
+                spanned(span, Import(crate::Import {
+                    mode: ImportMode::RawText,
+                    ..imp
+                }))
+            },
+            [import_hashed(imp), Location(_)] => {
+                spanned(span, Import(crate::Import {
+                    mode: ImportMode::Location,
+                    ..imp
+                }))
+            },
+        ))
+    }
 
-    rule!(lambda<()>);
-    rule!(forall<()>);
-    rule!(arrow<()>);
-    rule!(merge<()>);
-    rule!(assert<()>);
-    rule!(if_<()>);
-    rule!(in_<()>);
-    rule!(toMap<()>);
+    fn lambda(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+    fn forall(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+    fn arrow(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+    fn merge(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+    fn assert(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+    fn if_(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+    fn in_(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+    fn toMap(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
 
-    rule!(empty_list_literal<ParsedExpr>; span; children!(
-        [application_expression(e)] => {
-            spanned(span, EmptyListLit(e))
-        },
-    ));
+    fn empty_list_literal(input: ParseInput<Rule>) -> ParseResult<ParsedExpr> {
+        let span = input.as_span();
+        Ok(parse_children!(input;
+            [application_expression(e)] => {
+                spanned(span, EmptyListLit(e))
+            },
+        ))
+    }
 
-    rule!(expression<ParsedExpr>; span; children!(
-        [lambda(()), label(l), expression(typ),
-                arrow(()), expression(body)] => {
-            spanned(span, Lam(l, typ, body))
-        },
-        [if_(()), expression(cond), expression(left), expression(right)] => {
-            spanned(span, BoolIf(cond, left, right))
-        },
-        [let_binding(bindings).., in_(()), expression(final_expr)] => {
-            bindings.rev().fold(
-                final_expr,
-                |acc, x| unspanned(Let(x.0, x.1, x.2, acc))
+    fn expression(input: ParseInput<Rule>) -> ParseResult<ParsedExpr> {
+        let span = input.as_span();
+        Ok(parse_children!(input;
+            [lambda(()), label(l), expression(typ),
+                    arrow(()), expression(body)] => {
+                spanned(span, Lam(l, typ, body))
+            },
+            [if_(()), expression(cond), expression(left),
+                    expression(right)] => {
+                spanned(span, BoolIf(cond, left, right))
+            },
+            [let_binding(bindings).., in_(()), expression(final_expr)] => {
+                bindings.rev().fold(
+                    final_expr,
+                    |acc, x| unspanned(Let(x.0, x.1, x.2, acc))
+                )
+            },
+            [forall(()), label(l), expression(typ),
+                    arrow(()), expression(body)] => {
+                spanned(span, Pi(l, typ, body))
+            },
+            [operator_expression(typ), arrow(()), expression(body)] => {
+                spanned(span, Pi("_".into(), typ, body))
+            },
+            [merge(()), import_expression(x), import_expression(y),
+                    application_expression(z)] => {
+                spanned(span, Merge(x, y, Some(z)))
+            },
+            [empty_list_literal(e)] => e,
+            [assert(()), expression(x)] => {
+                spanned(span, Assert(x))
+            },
+            [toMap(()), import_expression(x), application_expression(y)] => {
+                spanned(span, ToMap(x, Some(y)))
+            },
+            [operator_expression(e)] => e,
+            [operator_expression(e), expression(annot)] => {
+                spanned(span, Annot(e, annot))
+            },
+        ))
+    }
+
+    fn let_binding(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<(Label, Option<ParsedExpr>, ParsedExpr)> {
+        Ok(parse_children!(input;
+            [label(name), expression(annot), expression(expr)] =>
+                (name, Some(annot), expr),
+            [label(name), expression(expr)] =>
+                (name, None, expr),
+        ))
+    }
+
+    fn List(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+    fn Optional(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+
+    #[prec_climb(application_expression, make_precclimber())]
+    fn operator_expression(
+        input: ParseInput<Rule>,
+        l: ParsedExpr,
+        op: Pair<Rule>,
+        r: ParsedExpr,
+    ) -> ParseResult<ParsedExpr> {
+        use crate::BinOp::*;
+        use Rule::*;
+        let op = match op.as_rule() {
+            import_alt => ImportAlt,
+            bool_or => BoolOr,
+            natural_plus => NaturalPlus,
+            text_append => TextAppend,
+            list_append => ListAppend,
+            bool_and => BoolAnd,
+            combine => RecursiveRecordMerge,
+            prefer => RightBiasedRecordMerge,
+            combine_types => RecursiveRecordTypeMerge,
+            natural_times => NaturalTimes,
+            bool_eq => BoolEQ,
+            bool_ne => BoolNE,
+            equivalent => Equivalence,
+            r => Err(input.error(format!("Rule {:?} isn't an operator", r)))?,
+        };
+
+        Ok(unspanned(BinOp(op, l, r)))
+    }
+
+    fn Some_(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+
+    fn application_expression(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<ParsedExpr> {
+        Ok(parse_children!(input;
+            [first_application_expression(e)] => e,
+            [first_application_expression(first),
+                    import_expression(rest)..] => {
+                rest.fold(first, |acc, e| unspanned(App(acc, e)))
+            },
+        ))
+    }
+
+    fn first_application_expression(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<ParsedExpr> {
+        let span = input.as_span();
+        Ok(parse_children!(input;
+            [Some_(()), import_expression(e)] => {
+                spanned(span, SomeLit(e))
+            },
+            [merge(()), import_expression(x), import_expression(y)] => {
+                spanned(span, Merge(x, y, None))
+            },
+            [toMap(()), import_expression(x)] => {
+                spanned(span, ToMap(x, None))
+            },
+            [import_expression(e)] => e,
+        ))
+    }
+
+    fn import_expression(input: ParseInput<Rule>) -> ParseResult<ParsedExpr> {
+        Ok(parse_children!(input;
+            [selector_expression(e)] => e,
+            [import(e)] => e,
+        ))
+    }
+
+    fn selector_expression(input: ParseInput<Rule>) -> ParseResult<ParsedExpr> {
+        Ok(parse_children!(input;
+            [primitive_expression(e)] => e,
+            [primitive_expression(first), selector(rest)..] => {
+                rest.fold(first, |acc, e| unspanned(match e {
+                    Either::Left(l) => Field(acc, l),
+                    Either::Right(ls) => Projection(acc, ls),
+                }))
+            },
+        ))
+    }
+
+    fn selector(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<Either<Label, DupTreeSet<Label>>> {
+        Ok(parse_children!(input;
+            [label(l)] => Either::Left(l),
+            [labels(ls)] => Either::Right(ls),
+            [expression(_e)] => unimplemented!("selection by expression"), // TODO
+        ))
+    }
+
+    fn labels(input: ParseInput<Rule>) -> ParseResult<DupTreeSet<Label>> {
+        Ok(parse_children!(input;
+            [label(ls)..] => ls.collect(),
+        ))
+    }
+
+    fn primitive_expression(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<ParsedExpr> {
+        let span = input.as_span();
+        Ok(parse_children!(input;
+            [double_literal(n)] => spanned(span, DoubleLit(n)),
+            [natural_literal(n)] => spanned(span, NaturalLit(n)),
+            [integer_literal(n)] => spanned(span, IntegerLit(n)),
+            [double_quote_literal(s)] => spanned(span, TextLit(s)),
+            [single_quote_literal(s)] => spanned(span, TextLit(s)),
+            [empty_record_type(e)] => e,
+            [empty_record_literal(e)] => e,
+            [non_empty_record_type_or_literal(e)] => e,
+            [union_type(e)] => e,
+            [non_empty_list_literal(e)] => e,
+            [identifier(e)] => e,
+            [expression(e)] => e,
+        ))
+    }
+
+    fn empty_record_literal(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<ParsedExpr> {
+        let span = input.as_span();
+        Ok(spanned(span, RecordLit(Default::default())))
+    }
+
+    fn empty_record_type(input: ParseInput<Rule>) -> ParseResult<ParsedExpr> {
+        let span = input.as_span();
+        Ok(spanned(span, RecordType(Default::default())))
+    }
+
+    fn non_empty_record_type_or_literal(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<ParsedExpr> {
+        let span = input.as_span();
+        Ok(parse_children!(input;
+            [label(first_label), non_empty_record_type(rest)] => {
+                let (first_expr, mut map) = rest;
+                map.insert(first_label, first_expr);
+                spanned(span, RecordType(map))
+            },
+            [label(first_label), non_empty_record_literal(rest)] => {
+                let (first_expr, mut map) = rest;
+                map.insert(first_label, first_expr);
+                spanned(span, RecordLit(map))
+            },
+        ))
+    }
+
+    fn non_empty_record_type(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<(ParsedExpr, DupTreeMap<Label, ParsedExpr>)> {
+        Ok(parse_children!(input;
+            [expression(expr), record_type_entry(entries)..] => {
+                (expr, entries.collect())
+            }
+        ))
+    }
+
+    fn record_type_entry(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<(Label, ParsedExpr)> {
+        Ok(parse_children!(input;
+            [label(name), expression(expr)] => (name, expr)
+        ))
+    }
+
+    fn non_empty_record_literal(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<(ParsedExpr, DupTreeMap<Label, ParsedExpr>)> {
+        Ok(parse_children!(input;
+            [expression(expr), record_literal_entry(entries)..] => {
+                (expr, entries.collect())
+            }
+        ))
+    }
+
+    fn record_literal_entry(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<(Label, ParsedExpr)> {
+        Ok(parse_children!(input;
+            [label(name), expression(expr)] => (name, expr)
+        ))
+    }
+
+    fn union_type(input: ParseInput<Rule>) -> ParseResult<ParsedExpr> {
+        let span = input.as_span();
+        Ok(parse_children!(input;
+            [empty_union_type(_)] => {
+                spanned(span, UnionType(Default::default()))
+            },
+            [union_type_entry(entries)..] => {
+                spanned(span, UnionType(entries.collect()))
+            },
+        ))
+    }
+
+    fn empty_union_type(_: ParseInput<Rule>) -> ParseResult<()> {
+        Ok(())
+    }
+
+    fn union_type_entry(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<(Label, Option<ParsedExpr>)> {
+        Ok(parse_children!(input;
+            [label(name), expression(expr)] => (name, Some(expr)),
+            [label(name)] => (name, None),
+        ))
+    }
+
+    fn non_empty_list_literal(
+        input: ParseInput<Rule>,
+    ) -> ParseResult<ParsedExpr> {
+        let span = input.as_span();
+        Ok(parse_children!(input;
+            [expression(items)..] => spanned(
+                span,
+                NEListLit(items.collect())
             )
-        },
-        [forall(()), label(l), expression(typ),
-                arrow(()), expression(body)] => {
-            spanned(span, Pi(l, typ, body))
-        },
-        [operator_expression(typ), arrow(()), expression(body)] => {
-            spanned(span, Pi("_".into(), typ, body))
-        },
-        [merge(()), import_expression(x), import_expression(y),
-                application_expression(z)] => {
-            spanned(span, Merge(x, y, Some(z)))
-        },
-        [empty_list_literal(e)] => e,
-        [assert(()), expression(x)] => {
-            spanned(span, Assert(x))
-        },
-        [toMap(()), import_expression(x), application_expression(y)] => {
-            spanned(span, ToMap(x, Some(y)))
-        },
-        [operator_expression(e)] => e,
-        [operator_expression(e), expression(annot)] => {
-            spanned(span, Annot(e, annot))
-        },
-    ));
+        ))
+    }
 
-    rule!(let_binding<(Label, Option<ParsedExpr>, ParsedExpr)>;
-            children!(
-        [label(name), expression(annot), expression(expr)] =>
-            (name, Some(annot), expr),
-        [label(name), expression(expr)] =>
-            (name, None, expr),
-    ));
-
-    rule!(List<()>);
-    rule!(Optional<()>);
-
-    rule!(operator_expression<ParsedExpr>; prec_climb!(
-        application_expression,
-        {
-            use Rule::*;
-            // In order of precedence
-            let operators = vec![
-                import_alt,
-                bool_or,
-                natural_plus,
-                text_append,
-                list_append,
-                bool_and,
-                combine,
-                prefer,
-                combine_types,
-                natural_times,
-                bool_eq,
-                bool_ne,
-                equivalent,
-            ];
-            PrecClimber::new(
-                operators
-                    .into_iter()
-                    .map(|op| pcl::Operator::new(op, pcl::Assoc::Left))
-                    .collect(),
-            )
-        },
-        (l, op, r) => {
-            use crate::BinOp::*;
-            use Rule::*;
-            let op = match op.as_rule() {
-                import_alt => ImportAlt,
-                bool_or => BoolOr,
-                natural_plus => NaturalPlus,
-                text_append => TextAppend,
-                list_append => ListAppend,
-                bool_and => BoolAnd,
-                combine => RecursiveRecordMerge,
-                prefer => RightBiasedRecordMerge,
-                combine_types => RecursiveRecordTypeMerge,
-                natural_times => NaturalTimes,
-                bool_eq => BoolEQ,
-                bool_ne => BoolNE,
-                equivalent => Equivalence,
-                r => Err(
-                    format!("Rule {:?} isn't an operator", r),
-                )?,
-            };
-
-            unspanned(BinOp(op, l, r))
-        }
-    ));
-
-    rule!(Some_<()>);
-
-    rule!(application_expression<ParsedExpr>; children!(
-        [first_application_expression(e)] => e,
-        [first_application_expression(first), import_expression(rest)..] => {
-            rest.fold(first, |acc, e| unspanned(App(acc, e)))
-        },
-    ));
-
-    rule!(first_application_expression<ParsedExpr>; span;
-            children!(
-        [Some_(()), import_expression(e)] => {
-            spanned(span, SomeLit(e))
-        },
-        [merge(()), import_expression(x), import_expression(y)] => {
-            spanned(span, Merge(x, y, None))
-        },
-        [toMap(()), import_expression(x)] => {
-            spanned(span, ToMap(x, None))
-        },
-        [import_expression(e)] => e,
-    ));
-
-    rule!(import_expression<ParsedExpr>;
-            children!(
-        [selector_expression(e)] => e,
-        [import(e)] => e,
-    ));
-
-    rule!(selector_expression<ParsedExpr>; children!(
-        [primitive_expression(e)] => e,
-        [primitive_expression(first), selector(rest)..] => {
-            rest.fold(first, |acc, e| unspanned(match e {
-                Either::Left(l) => Field(acc, l),
-                Either::Right(ls) => Projection(acc, ls),
-            }))
-        },
-    ));
-
-    rule!(selector<Either<Label, DupTreeSet<Label>>>; children!(
-        [label(l)] => Either::Left(l),
-        [labels(ls)] => Either::Right(ls),
-        [expression(_e)] => unimplemented!("selection by expression"), // TODO
-    ));
-
-    rule!(labels<DupTreeSet<Label>>; children!(
-        [label(ls)..] => ls.collect(),
-    ));
-
-    rule!(primitive_expression<ParsedExpr>; span; children!(
-        [double_literal(n)] => spanned(span, DoubleLit(n)),
-        [natural_literal(n)] => spanned(span, NaturalLit(n)),
-        [integer_literal(n)] => spanned(span, IntegerLit(n)),
-        [double_quote_literal(s)] => spanned(span, TextLit(s)),
-        [single_quote_literal(s)] => spanned(span, TextLit(s)),
-        [empty_record_type(e)] => e,
-        [empty_record_literal(e)] => e,
-        [non_empty_record_type_or_literal(e)] => e,
-        [union_type(e)] => e,
-        [non_empty_list_literal(e)] => e,
-        [identifier(e)] => e,
-        [expression(e)] => e,
-    ));
-
-    rule!(empty_record_literal<ParsedExpr>; span;
-        captured_str!(_) => spanned(span, RecordLit(Default::default()))
-    );
-
-    rule!(empty_record_type<ParsedExpr>; span;
-        captured_str!(_) => spanned(span, RecordType(Default::default()))
-    );
-
-    rule!(non_empty_record_type_or_literal<ParsedExpr>; span;
-          children!(
-        [label(first_label), non_empty_record_type(rest)] => {
-            let (first_expr, mut map) = rest;
-            map.insert(first_label, first_expr);
-            spanned(span, RecordType(map))
-        },
-        [label(first_label), non_empty_record_literal(rest)] => {
-            let (first_expr, mut map) = rest;
-            map.insert(first_label, first_expr);
-            spanned(span, RecordLit(map))
-        },
-    ));
-
-    rule!(non_empty_record_type
-          <(ParsedExpr, DupTreeMap<Label, ParsedExpr>)>; children!(
-        [expression(expr), record_type_entry(entries)..] => {
-            (expr, entries.collect())
-        }
-    ));
-
-    rule!(record_type_entry<(Label, ParsedExpr)>; children!(
-        [label(name), expression(expr)] => (name, expr)
-    ));
-
-    rule!(non_empty_record_literal
-          <(ParsedExpr, DupTreeMap<Label, ParsedExpr>)>; children!(
-        [expression(expr), record_literal_entry(entries)..] => {
-            (expr, entries.collect())
-        }
-    ));
-
-    rule!(record_literal_entry<(Label, ParsedExpr)>; children!(
-        [label(name), expression(expr)] => (name, expr)
-    ));
-
-    rule!(union_type<ParsedExpr>; span; children!(
-        [empty_union_type(_)] => {
-            spanned(span, UnionType(Default::default()))
-        },
-        [union_type_entry(entries)..] => {
-            spanned(span, UnionType(entries.collect()))
-        },
-    ));
-
-    rule!(empty_union_type<()>);
-
-    rule!(union_type_entry<(Label, Option<ParsedExpr>)>; children!(
-        [label(name), expression(expr)] => (name, Some(expr)),
-        [label(name)] => (name, None),
-    ));
-
-    rule!(non_empty_list_literal<ParsedExpr>; span;
-          children!(
-        [expression(items)..] => spanned(
-            span,
-            NEListLit(items.collect())
-        )
-    ));
-
-    rule!(final_expression<ParsedExpr>; children!(
-        [expression(e), EOI(_)] => e
-    ));
+    fn final_expression(input: ParseInput<Rule>) -> ParseResult<ParsedExpr> {
+        Ok(parse_children!(input;
+            [expression(e), EOI(_)] => e
+        ))
+    }
 }
 
 pub fn parse_expr(s: &str) -> ParseResult<ParsedExpr> {
     let mut pairs = DhallParser::parse(Rule::final_expression, s)?;
-    let rc_input = s.to_string().into();
-    let expr = EntryPoint::final_expression(rc_input, pairs.next().unwrap())?;
+    let expr = EntryPoint::final_expression(s, pairs.next().unwrap())?;
     assert_eq!(pairs.next(), None);
     Ok(expr)
 }

--- a/dhall_syntax/src/parser.rs
+++ b/dhall_syntax/src/parser.rs
@@ -215,7 +215,8 @@ fn make_precclimber() -> PrecClimber<Rule> {
     )
 }
 
-make_parser! {
+#[make_parser]
+impl _ {
     fn EOI(_: ParseInput<Rule>) -> ParseResult<()> {
         Ok(())
     }


### PR DESCRIPTION
Benefits:
- the parser code is wayyy less magical
- better error messages when a comma is missing
- it is finally possible to parse directly an `Expr<E>` for any E
- rustfmt accepts to format the parser code
- parser macros could be published as a useful independent crate
- rule aliasing and shortcutting can now be reimplemented
- more possibilities of future extension