### PR TITLE
Resolve imports by mutating Expr instead of cloning it 

### DIFF
--- a/dhall/src/phase/mod.rs
+++ b/dhall/src/phase/mod.rs
@@ -16,8 +16,8 @@ pub(crate) mod parse;
 pub(crate) mod resolve;
 pub(crate) mod typecheck;
 
-pub type ParsedExpr = Expr<!>;
-pub type DecodedExpr = Expr<!>;
+pub type ParsedExpr = Expr<Normalized>;
+pub type DecodedExpr = Expr<Normalized>;
 pub type ResolvedExpr = Expr<Normalized>;
 pub type NormalizedExpr = Expr<Normalized>;
 

--- a/dhall/src/phase/resolve.rs
+++ b/dhall/src/phase/resolve.rs
@@ -58,18 +58,16 @@ fn load_import(
 }
 
 fn do_resolve_expr(
-    Parsed(expr, root): Parsed,
+    parsed: Parsed,
     import_cache: &mut ImportCache,
     import_stack: &ImportStack,
 ) -> Result<Resolved, ImportError> {
-    let resolve = |import: &Import| -> Result<Normalized, ImportError> {
-        if import_stack.contains(import) {
-            return Err(ImportError::ImportCycle(
-                import_stack.clone(),
-                import.clone(),
-            ));
+    let Parsed(mut expr, root) = parsed;
+    let mut resolve = |import: Import| -> Result<Normalized, ImportError> {
+        if import_stack.contains(&import) {
+            return Err(ImportError::ImportCycle(import_stack.clone(), import));
         }
-        match import_cache.get(import) {
+        match import_cache.get(&import) {
             Some(expr) => Ok(expr.clone()),
             None => {
                 // Copy the import stack and push the current import
@@ -77,16 +75,20 @@ fn do_resolve_expr(
                 import_stack.push(import.clone());
 
                 // Resolve the import recursively
-                let expr =
-                    resolve_import(import, &root, import_cache, &import_stack)?;
+                let expr = resolve_import(
+                    &import,
+                    &root,
+                    import_cache,
+                    &import_stack,
+                )?;
 
                 // Add the import to the cache
-                import_cache.insert(import.clone(), expr.clone());
+                import_cache.insert(import, expr.clone());
                 Ok(expr)
             }
         }
     };
-    let expr = expr.traverse_resolve(resolve)?;
+    expr.traverse_resolve_mut(&mut resolve)?;
     Ok(Resolved(expr))
 }
 
@@ -95,12 +97,13 @@ pub(crate) fn resolve(e: Parsed) -> Result<Resolved, ImportError> {
 }
 
 pub(crate) fn skip_resolve_expr(
-    Parsed(expr, _root): Parsed,
+    parsed: Parsed,
 ) -> Result<Resolved, ImportError> {
-    let resolve = |import: &Import| -> Result<Normalized, ImportError> {
-        Err(ImportError::UnexpectedImport(import.clone()))
+    let mut expr = parsed.0;
+    let mut resolve = |import: Import| -> Result<Normalized, ImportError> {
+        Err(ImportError::UnexpectedImport(import))
     };
-    let expr = expr.traverse_resolve(resolve)?;
+    expr.traverse_resolve_mut(&mut resolve)?;
     Ok(Resolved(expr))
 }
 
@@ -131,9 +134,9 @@ mod spec_tests {
     // import_success!(success_alternativeEnvNatural, "alternativeEnvNatural");
     // import_success!(success_alternativeEnvSimple, "alternativeEnvSimple");
     // import_success!(success_alternativeHashMismatch, "alternativeHashMismatch");
-    // import_success!(success_alternativeNatural, "alternativeNatural");
-    // import_success!(success_alternativeParseError, "alternativeParseError");
-    // import_success!(success_alternativeTypeError, "alternativeTypeError");
+    import_success!(success_alternativeNatural, "alternativeNatural");
+    import_success!(success_alternativeParseError, "alternativeParseError");
+    import_success!(success_alternativeTypeError, "alternativeTypeError");
     // import_success!(success_asLocation, "asLocation");
     // import_success!(success_asText, "asText");
     // import_success!(success_customHeaders, "customHeaders");

--- a/dhall_syntax/src/core/expr.rs
+++ b/dhall_syntax/src/core/expr.rs
@@ -313,21 +313,25 @@ impl<SE, E> ExprF<SE, E> {
 }
 
 impl<E> RawExpr<E> {
-    pub fn traverse_resolve<E2, Err>(
+    pub fn traverse_resolve<Err>(
         &self,
-        visit_import: impl FnMut(&Import<Expr<E2>>) -> Result<E2, Err>,
-    ) -> Result<RawExpr<E2>, Err> {
+        visit_import: impl FnMut(&Import<Expr<E>>) -> Result<E, Err>,
+    ) -> Result<RawExpr<E>, Err>
+    where
+        E: Clone,
+    {
         self.traverse_resolve_with_visitor(&mut visitor::ResolveVisitor(
             visit_import,
         ))
     }
 
-    pub(crate) fn traverse_resolve_with_visitor<E2, Err, F1>(
+    pub(crate) fn traverse_resolve_with_visitor<Err, F1>(
         &self,
         visitor: &mut visitor::ResolveVisitor<F1>,
-    ) -> Result<RawExpr<E2>, Err>
+    ) -> Result<RawExpr<E>, Err>
     where
-        F1: FnMut(&Import<Expr<E2>>) -> Result<E2, Err>,
+        E: Clone,
+        F1: FnMut(&Import<Expr<E>>) -> Result<E, Err>,
     {
         match self {
             ExprF::BinOp(BinOp::ImportAlt, l, r) => l
@@ -368,10 +372,13 @@ impl<E> Expr<E> {
 }
 
 impl<E> Expr<E> {
-    pub fn traverse_resolve<E2, Err>(
+    pub fn traverse_resolve<Err>(
         &self,
-        visit_import: impl FnMut(&Import<Expr<E2>>) -> Result<E2, Err>,
-    ) -> Result<Expr<E2>, Err> {
+        visit_import: impl FnMut(&Import<Expr<E>>) -> Result<E, Err>,
+    ) -> Result<Expr<E>, Err>
+    where
+        E: Clone,
+    {
         Ok(self.rewrap(self.as_ref().traverse_resolve(visit_import)?))
     }
 }

--- a/dhall_syntax/src/core/import.rs
+++ b/dhall_syntax/src/core/import.rs
@@ -57,7 +57,7 @@ pub struct Import<SubExpr> {
 }
 
 impl<SE> URL<SE> {
-    pub fn visit_subexpr<'a, Err, SE2>(
+    pub fn traverse_ref<'a, Err, SE2>(
         &'a self,
         f: impl FnOnce(&'a SE) -> Result<SE2, Err>,
     ) -> Result<URL<SE2>, Err> {
@@ -70,32 +70,56 @@ impl<SE> URL<SE> {
             headers,
         })
     }
+    pub fn traverse_mut<'a, Err>(
+        &'a mut self,
+        f: impl FnOnce(&'a mut SE) -> Result<(), Err>,
+    ) -> Result<(), Err> {
+        if let Some(header) = &mut self.headers {
+            f(header)?;
+        }
+        Ok(())
+    }
 }
 
 impl<SE> ImportLocation<SE> {
-    pub fn visit_subexpr<'a, Err, SE2>(
+    pub fn traverse_ref<'a, Err, SE2>(
         &'a self,
         f: impl FnOnce(&'a SE) -> Result<SE2, Err>,
     ) -> Result<ImportLocation<SE2>, Err> {
         use ImportLocation::*;
         Ok(match self {
             Local(prefix, path) => Local(*prefix, path.clone()),
-            Remote(url) => Remote(url.visit_subexpr(f)?),
+            Remote(url) => Remote(url.traverse_ref(f)?),
             Env(env) => Env(env.clone()),
             Missing => Missing,
         })
     }
+    pub fn traverse_mut<'a, Err>(
+        &'a mut self,
+        f: impl FnOnce(&'a mut SE) -> Result<(), Err>,
+    ) -> Result<(), Err> {
+        if let ImportLocation::Remote(url) = self {
+            url.traverse_mut(f)?;
+        }
+        Ok(())
+    }
 }
 
 impl<SE> Import<SE> {
-    pub fn visit_subexpr<'a, Err, SE2>(
+    pub fn traverse_ref<'a, Err, SE2>(
         &'a self,
         f: impl FnOnce(&'a SE) -> Result<SE2, Err>,
     ) -> Result<Import<SE2>, Err> {
         Ok(Import {
             mode: self.mode,
-            location: self.location.visit_subexpr(f)?,
+            location: self.location.traverse_ref(f)?,
             hash: self.hash.clone(),
         })
+    }
+    pub fn traverse_mut<'a, Err>(
+        &'a mut self,
+        f: impl FnOnce(&'a mut SE) -> Result<(), Err>,
+    ) -> Result<(), Err> {
+        self.location.traverse_mut(f)
     }
 }

--- a/dhall_syntax/src/core/text.rs
+++ b/dhall_syntax/src/core/text.rs
@@ -76,6 +76,16 @@ impl<SubExpr> InterpolatedText<SubExpr> {
         })
     }
 
+    pub fn traverse_mut<'a, E, F>(&'a mut self, mut f: F) -> Result<(), E>
+    where
+        F: FnMut(&'a mut SubExpr) -> Result<(), E>,
+    {
+        for (e, _) in &mut self.tail {
+            f(e)?
+        }
+        Ok(())
+    }
+
     pub fn iter<'a>(
         &'a self,
     ) -> impl Iterator<Item = InterpolatedTextContents<&'a SubExpr>> + 'a {

--- a/dhall_syntax/src/core/visitor.rs
+++ b/dhall_syntax/src/core/visitor.rs
@@ -1,11 +1,6 @@
 use crate::*;
 use std::iter::FromIterator;
 
-/// A way too generic Visitor trait.
-pub trait GenericVisitor<Input, Output>: Sized {
-    fn visit(self, input: Input) -> Output;
-}
-
 /// A visitor trait that can be used to traverse `ExprF`s. We need this pattern so that Rust lets
 /// us have as much mutability as we can.
 /// For example, `traverse_ref_with_special_handling_of_binders` cannot be made using only
@@ -14,7 +9,7 @@ pub trait GenericVisitor<Input, Output>: Sized {
 /// preventing exactly this ! So we have to be more clever. The visitor pattern allows us to have
 /// only one mutable thing the whole time: the visitor itself. The visitor can then carry around
 /// multiple closures or just one, and Rust is ok with either. See for example TraverseRefVisitor.
-pub trait ExprFFallibleVisitor<'a, SE1, SE2, E1, E2>: Sized {
+pub trait ExprFVisitor<'a, SE1, SE2, E1, E2>: Sized {
     type Error;
 
     fn visit_subexpr(&mut self, subexpr: &'a SE1) -> Result<SE2, Self::Error>;
@@ -27,174 +22,263 @@ pub trait ExprFFallibleVisitor<'a, SE1, SE2, E1, E2>: Sized {
     ) -> Result<SE2, Self::Error> {
         self.visit_subexpr(subexpr)
     }
-}
 
-/// Like ExprFFallibleVisitor, but without the error handling.
-pub trait ExprFInFallibleVisitor<'a, SE1, SE2, E1, E2>: Sized {
-    fn visit_subexpr(&mut self, subexpr: &'a SE1) -> SE2;
-    fn visit_embed(self, embed: &'a E1) -> E2;
-
-    fn visit_subexpr_under_binder(
-        mut self,
-        _label: &'a Label,
-        subexpr: &'a SE1,
-    ) -> SE2 {
-        self.visit_subexpr(subexpr)
-    }
-}
-
-impl<'a, T, SE1, SE2, E1, E2>
-    GenericVisitor<&'a ExprF<SE1, E1>, Result<ExprF<SE2, E2>, T::Error>> for T
-where
-    T: ExprFFallibleVisitor<'a, SE1, SE2, E1, E2>,
-{
     fn visit(
         self,
         input: &'a ExprF<SE1, E1>,
-    ) -> Result<ExprF<SE2, E2>, T::Error> {
-        fn vec<'a, T, U, Err, F: FnMut(&'a T) -> Result<U, Err>>(
-            x: &'a [T],
-            f: F,
-        ) -> Result<Vec<U>, Err> {
-            x.iter().map(f).collect()
-        }
-        fn opt<'a, T, U, Err, F: FnOnce(&'a T) -> Result<U, Err>>(
-            x: &'a Option<T>,
-            f: F,
-        ) -> Result<Option<U>, Err> {
-            Ok(match x {
-                Some(x) => Some(f(x)?),
-                None => None,
-            })
-        }
-        fn dupmap<'a, V, SE1, SE2, E1, E2, T>(
-            x: impl IntoIterator<Item = (&'a Label, &'a SE1)>,
-            mut v: V,
-        ) -> Result<T, V::Error>
-        where
-            SE1: 'a,
-            T: FromIterator<(Label, SE2)>,
-            V: ExprFFallibleVisitor<'a, SE1, SE2, E1, E2>,
-        {
-            x.into_iter()
-                .map(|(k, x)| Ok((k.clone(), v.visit_subexpr(x)?)))
-                .collect()
-        }
-        fn optdupmap<'a, V, SE1, SE2, E1, E2, T>(
-            x: impl IntoIterator<Item = (&'a Label, &'a Option<SE1>)>,
-            mut v: V,
-        ) -> Result<T, V::Error>
-        where
-            SE1: 'a,
-            T: FromIterator<(Label, Option<SE2>)>,
-            V: ExprFFallibleVisitor<'a, SE1, SE2, E1, E2>,
-        {
-            x.into_iter()
-                .map(|(k, x)| {
-                    Ok((
-                        k.clone(),
-                        match x {
-                            Some(x) => Some(v.visit_subexpr(x)?),
-                            None => None,
-                        },
-                    ))
-                })
-                .collect()
-        }
-
-        let mut v = self;
-        use crate::ExprF::*;
-        Ok(match input {
-            Var(v) => Var(v.clone()),
-            Lam(l, t, e) => {
-                let t = v.visit_subexpr(t)?;
-                let e = v.visit_subexpr_under_binder(l, e)?;
-                Lam(l.clone(), t, e)
-            }
-            Pi(l, t, e) => {
-                let t = v.visit_subexpr(t)?;
-                let e = v.visit_subexpr_under_binder(l, e)?;
-                Pi(l.clone(), t, e)
-            }
-            Let(l, t, a, e) => {
-                let t = opt(t, &mut |e| v.visit_subexpr(e))?;
-                let a = v.visit_subexpr(a)?;
-                let e = v.visit_subexpr_under_binder(l, e)?;
-                Let(l.clone(), t, a, e)
-            }
-            App(f, a) => App(v.visit_subexpr(f)?, v.visit_subexpr(a)?),
-            Annot(x, t) => Annot(v.visit_subexpr(x)?, v.visit_subexpr(t)?),
-            Const(k) => Const(*k),
-            Builtin(v) => Builtin(*v),
-            BoolLit(b) => BoolLit(*b),
-            NaturalLit(n) => NaturalLit(*n),
-            IntegerLit(n) => IntegerLit(*n),
-            DoubleLit(n) => DoubleLit(*n),
-            TextLit(t) => TextLit(t.traverse_ref(|e| v.visit_subexpr(e))?),
-            BinOp(o, x, y) => {
-                BinOp(*o, v.visit_subexpr(x)?, v.visit_subexpr(y)?)
-            }
-            BoolIf(b, t, f) => BoolIf(
-                v.visit_subexpr(b)?,
-                v.visit_subexpr(t)?,
-                v.visit_subexpr(f)?,
-            ),
-            EmptyListLit(t) => EmptyListLit(v.visit_subexpr(t)?),
-            NEListLit(es) => NEListLit(vec(es, |e| v.visit_subexpr(e))?),
-            SomeLit(e) => SomeLit(v.visit_subexpr(e)?),
-            RecordType(kts) => RecordType(dupmap(kts, v)?),
-            RecordLit(kvs) => RecordLit(dupmap(kvs, v)?),
-            UnionType(kts) => UnionType(optdupmap(kts, v)?),
-            Merge(x, y, t) => Merge(
-                v.visit_subexpr(x)?,
-                v.visit_subexpr(y)?,
-                opt(t, |e| v.visit_subexpr(e))?,
-            ),
-            ToMap(x, t) => {
-                ToMap(v.visit_subexpr(x)?, opt(t, |e| v.visit_subexpr(e))?)
-            }
-            Field(e, l) => Field(v.visit_subexpr(e)?, l.clone()),
-            Projection(e, ls) => Projection(v.visit_subexpr(e)?, ls.clone()),
-            Assert(e) => Assert(v.visit_subexpr(e)?),
-            Import(i) => Import(i.visit_subexpr(|e| v.visit_subexpr(e))?),
-            Embed(a) => Embed(v.visit_embed(a)?),
-        })
+    ) -> Result<ExprF<SE2, E2>, Self::Error> {
+        visit_ref(self, input)
     }
 }
 
-impl<'a, T, SE1, SE2, E1, E2> GenericVisitor<&'a ExprF<SE1, E1>, ExprF<SE2, E2>>
-    for T
-where
-    T: ExprFInFallibleVisitor<'a, SE1, SE2, E1, E2>,
-{
-    fn visit(self, input: &'a ExprF<SE1, E1>) -> ExprF<SE2, E2> {
-        trivial_result(InfallibleWrapper(self).visit(input))
-    }
-}
+/// Like `ExprFVisitor`, but by mutable reference
+pub trait ExprFMutVisitor<'a, SE, E>: Sized {
+    type Error;
 
-struct InfallibleWrapper<T>(T);
-
-impl<'a, T, SE1, SE2, E1, E2> ExprFFallibleVisitor<'a, SE1, SE2, E1, E2>
-    for InfallibleWrapper<T>
-where
-    T: ExprFInFallibleVisitor<'a, SE1, SE2, E1, E2>,
-{
-    type Error = !;
-
-    fn visit_subexpr(&mut self, subexpr: &'a SE1) -> Result<SE2, Self::Error> {
-        Ok(self.0.visit_subexpr(subexpr))
-    }
-    fn visit_embed(self, embed: &'a E1) -> Result<E2, Self::Error> {
-        Ok(self.0.visit_embed(embed))
+    fn visit_subexpr(&mut self, subexpr: &'a mut SE)
+        -> Result<(), Self::Error>;
+    fn visit_embed(self, _embed: &'a mut E) -> Result<(), Self::Error> {
+        Ok(())
     }
 
     fn visit_subexpr_under_binder(
-        self,
-        label: &'a Label,
-        subexpr: &'a SE1,
-    ) -> Result<SE2, Self::Error> {
-        Ok(self.0.visit_subexpr_under_binder(label, subexpr))
+        mut self,
+        _label: &'a mut Label,
+        subexpr: &'a mut SE,
+    ) -> Result<(), Self::Error> {
+        self.visit_subexpr(subexpr)
     }
+
+    fn visit(self, input: &'a mut ExprF<SE, E>) -> Result<(), Self::Error> {
+        visit_mut(self, input)
+    }
+}
+
+fn visit_ref<'a, V, SE1, SE2, E1, E2>(
+    mut v: V,
+    input: &'a ExprF<SE1, E1>,
+) -> Result<ExprF<SE2, E2>, V::Error>
+where
+    V: ExprFVisitor<'a, SE1, SE2, E1, E2>,
+{
+    fn vec<'a, T, U, Err, F: FnMut(&'a T) -> Result<U, Err>>(
+        x: &'a [T],
+        f: F,
+    ) -> Result<Vec<U>, Err> {
+        x.iter().map(f).collect()
+    }
+    fn opt<'a, T, U, Err, F: FnOnce(&'a T) -> Result<U, Err>>(
+        x: &'a Option<T>,
+        f: F,
+    ) -> Result<Option<U>, Err> {
+        Ok(match x {
+            Some(x) => Some(f(x)?),
+            None => None,
+        })
+    }
+    fn dupmap<'a, V, SE1, SE2, E1, E2, T>(
+        x: impl IntoIterator<Item = (&'a Label, &'a SE1)>,
+        mut v: V,
+    ) -> Result<T, V::Error>
+    where
+        SE1: 'a,
+        T: FromIterator<(Label, SE2)>,
+        V: ExprFVisitor<'a, SE1, SE2, E1, E2>,
+    {
+        x.into_iter()
+            .map(|(k, x)| Ok((k.clone(), v.visit_subexpr(x)?)))
+            .collect()
+    }
+    fn optdupmap<'a, V, SE1, SE2, E1, E2, T>(
+        x: impl IntoIterator<Item = (&'a Label, &'a Option<SE1>)>,
+        mut v: V,
+    ) -> Result<T, V::Error>
+    where
+        SE1: 'a,
+        T: FromIterator<(Label, Option<SE2>)>,
+        V: ExprFVisitor<'a, SE1, SE2, E1, E2>,
+    {
+        x.into_iter()
+            .map(|(k, x)| {
+                Ok((
+                    k.clone(),
+                    match x {
+                        Some(x) => Some(v.visit_subexpr(x)?),
+                        None => None,
+                    },
+                ))
+            })
+            .collect()
+    }
+
+    use crate::ExprF::*;
+    Ok(match input {
+        Var(v) => Var(v.clone()),
+        Lam(l, t, e) => {
+            let t = v.visit_subexpr(t)?;
+            let e = v.visit_subexpr_under_binder(l, e)?;
+            Lam(l.clone(), t, e)
+        }
+        Pi(l, t, e) => {
+            let t = v.visit_subexpr(t)?;
+            let e = v.visit_subexpr_under_binder(l, e)?;
+            Pi(l.clone(), t, e)
+        }
+        Let(l, t, a, e) => {
+            let t = opt(t, &mut |e| v.visit_subexpr(e))?;
+            let a = v.visit_subexpr(a)?;
+            let e = v.visit_subexpr_under_binder(l, e)?;
+            Let(l.clone(), t, a, e)
+        }
+        App(f, a) => App(v.visit_subexpr(f)?, v.visit_subexpr(a)?),
+        Annot(x, t) => Annot(v.visit_subexpr(x)?, v.visit_subexpr(t)?),
+        Const(k) => Const(*k),
+        Builtin(v) => Builtin(*v),
+        BoolLit(b) => BoolLit(*b),
+        NaturalLit(n) => NaturalLit(*n),
+        IntegerLit(n) => IntegerLit(*n),
+        DoubleLit(n) => DoubleLit(*n),
+        TextLit(t) => TextLit(t.traverse_ref(|e| v.visit_subexpr(e))?),
+        BinOp(o, x, y) => BinOp(*o, v.visit_subexpr(x)?, v.visit_subexpr(y)?),
+        BoolIf(b, t, f) => BoolIf(
+            v.visit_subexpr(b)?,
+            v.visit_subexpr(t)?,
+            v.visit_subexpr(f)?,
+        ),
+        EmptyListLit(t) => EmptyListLit(v.visit_subexpr(t)?),
+        NEListLit(es) => NEListLit(vec(es, |e| v.visit_subexpr(e))?),
+        SomeLit(e) => SomeLit(v.visit_subexpr(e)?),
+        RecordType(kts) => RecordType(dupmap(kts, v)?),
+        RecordLit(kvs) => RecordLit(dupmap(kvs, v)?),
+        UnionType(kts) => UnionType(optdupmap(kts, v)?),
+        Merge(x, y, t) => Merge(
+            v.visit_subexpr(x)?,
+            v.visit_subexpr(y)?,
+            opt(t, |e| v.visit_subexpr(e))?,
+        ),
+        ToMap(x, t) => {
+            ToMap(v.visit_subexpr(x)?, opt(t, |e| v.visit_subexpr(e))?)
+        }
+        Field(e, l) => Field(v.visit_subexpr(e)?, l.clone()),
+        Projection(e, ls) => Projection(v.visit_subexpr(e)?, ls.clone()),
+        Assert(e) => Assert(v.visit_subexpr(e)?),
+        Import(i) => Import(i.traverse_ref(|e| v.visit_subexpr(e))?),
+        Embed(a) => Embed(v.visit_embed(a)?),
+    })
+}
+
+fn visit_mut<'a, V, SE, E>(
+    mut v: V,
+    input: &'a mut ExprF<SE, E>,
+) -> Result<(), V::Error>
+where
+    V: ExprFMutVisitor<'a, SE, E>,
+{
+    fn vec<'a, V, SE, E>(v: &mut V, x: &'a mut Vec<SE>) -> Result<(), V::Error>
+    where
+        V: ExprFMutVisitor<'a, SE, E>,
+    {
+        for x in x {
+            v.visit_subexpr(x)?;
+        }
+        Ok(())
+    }
+    fn opt<'a, V, SE, E>(
+        v: &mut V,
+        x: &'a mut Option<SE>,
+    ) -> Result<(), V::Error>
+    where
+        V: ExprFMutVisitor<'a, SE, E>,
+    {
+        if let Some(x) = x {
+            v.visit_subexpr(x)?;
+        }
+        Ok(())
+    }
+    fn dupmap<'a, V, SE, E>(
+        mut v: V,
+        x: impl IntoIterator<Item = (&'a Label, &'a mut SE)>,
+    ) -> Result<(), V::Error>
+    where
+        SE: 'a,
+        V: ExprFMutVisitor<'a, SE, E>,
+    {
+        for (_, x) in x {
+            v.visit_subexpr(x)?;
+        }
+        Ok(())
+    }
+    fn optdupmap<'a, V, SE, E>(
+        mut v: V,
+        x: impl IntoIterator<Item = (&'a Label, &'a mut Option<SE>)>,
+    ) -> Result<(), V::Error>
+    where
+        SE: 'a,
+        V: ExprFMutVisitor<'a, SE, E>,
+    {
+        for (_, x) in x {
+            opt(&mut v, x)?;
+        }
+        Ok(())
+    }
+
+    use crate::ExprF::*;
+    match input {
+        Var(_) | Const(_) | Builtin(_) | BoolLit(_) | NaturalLit(_)
+        | IntegerLit(_) | DoubleLit(_) => {}
+        Lam(l, t, e) => {
+            v.visit_subexpr(t)?;
+            v.visit_subexpr_under_binder(l, e)?;
+        }
+        Pi(l, t, e) => {
+            v.visit_subexpr(t)?;
+            v.visit_subexpr_under_binder(l, e)?;
+        }
+        Let(l, t, a, e) => {
+            opt(&mut v, t)?;
+            v.visit_subexpr(a)?;
+            v.visit_subexpr_under_binder(l, e)?;
+        }
+        App(f, a) => {
+            v.visit_subexpr(f)?;
+            v.visit_subexpr(a)?;
+        }
+        Annot(x, t) => {
+            v.visit_subexpr(x)?;
+            v.visit_subexpr(t)?;
+        }
+        TextLit(t) => t.traverse_mut(|e| v.visit_subexpr(e))?,
+        BinOp(_, x, y) => {
+            v.visit_subexpr(x)?;
+            v.visit_subexpr(y)?;
+        }
+        BoolIf(b, t, f) => {
+            v.visit_subexpr(b)?;
+            v.visit_subexpr(t)?;
+            v.visit_subexpr(f)?;
+        }
+        EmptyListLit(t) => v.visit_subexpr(t)?,
+        NEListLit(es) => vec(&mut v, es)?,
+        SomeLit(e) => v.visit_subexpr(e)?,
+        RecordType(kts) => dupmap(v, kts)?,
+        RecordLit(kvs) => dupmap(v, kvs)?,
+        UnionType(kts) => optdupmap(v, kts)?,
+        Merge(x, y, t) => {
+            v.visit_subexpr(x)?;
+            v.visit_subexpr(y)?;
+            opt(&mut v, t)?;
+        }
+        ToMap(x, t) => {
+            v.visit_subexpr(x)?;
+            opt(&mut v, t)?;
+        }
+        Field(e, _) => v.visit_subexpr(e)?,
+        Projection(e, _) => v.visit_subexpr(e)?,
+        Assert(e) => v.visit_subexpr(e)?,
+        Import(i) => i.traverse_mut(|e| v.visit_subexpr(e))?,
+        Embed(a) => v.visit_embed(a)?,
+    }
+    Ok(())
 }
 
 pub struct TraverseRefWithBindersVisitor<F1, F2> {
@@ -202,7 +286,7 @@ pub struct TraverseRefWithBindersVisitor<F1, F2> {
     pub visit_under_binder: F2,
 }
 
-impl<'a, SE, E, SE2, Err, F1, F2> ExprFFallibleVisitor<'a, SE, SE2, E, E>
+impl<'a, SE, E, SE2, Err, F1, F2> ExprFVisitor<'a, SE, SE2, E, E>
     for TraverseRefWithBindersVisitor<F1, F2>
 where
     SE: 'a,
@@ -231,7 +315,7 @@ pub struct TraverseRefVisitor<F1> {
     pub visit_subexpr: F1,
 }
 
-impl<'a, SE, E, SE2, Err, F1> ExprFFallibleVisitor<'a, SE, SE2, E, E>
+impl<'a, SE, E, SE2, Err, F1> ExprFVisitor<'a, SE, SE2, E, E>
     for TraverseRefVisitor<F1>
 where
     SE: 'a,
@@ -248,27 +332,22 @@ where
     }
 }
 
-pub struct ResolveVisitor<F1>(pub F1);
+pub struct TraverseMutVisitor<F1> {
+    pub visit_subexpr: F1,
+}
 
-impl<'a, 'b, E, Err, F1> ExprFFallibleVisitor<'a, Expr<E>, Expr<E>, E, E>
-    for &'b mut ResolveVisitor<F1>
+impl<'a, SE, E, Err, F1> ExprFMutVisitor<'a, SE, E> for TraverseMutVisitor<F1>
 where
-    E: Clone,
-    F1: FnMut(&Import<Expr<E>>) -> Result<E, Err>,
+    SE: 'a,
+    E: 'a,
+    F1: FnMut(&'a mut SE) -> Result<(), Err>,
 {
     type Error = Err;
 
     fn visit_subexpr(
         &mut self,
-        subexpr: &'a Expr<E>,
-    ) -> Result<Expr<E>, Self::Error> {
-        Ok(subexpr.rewrap(
-            subexpr
-                .as_ref()
-                .traverse_resolve_with_visitor(&mut **self)?,
-        ))
-    }
-    fn visit_embed(self, embed: &'a E) -> Result<E, Self::Error> {
-        Ok(embed.clone())
+        subexpr: &'a mut SE,
+    ) -> Result<(), Self::Error> {
+        (self.visit_subexpr)(subexpr)
     }
 }

--- a/dhall_syntax/src/core/visitor.rs
+++ b/dhall_syntax/src/core/visitor.rs
@@ -250,24 +250,25 @@ where
 
 pub struct ResolveVisitor<F1>(pub F1);
 
-impl<'a, 'b, E, E2, Err, F1> ExprFFallibleVisitor<'a, Expr<E>, Expr<E2>, E, E2>
+impl<'a, 'b, E, Err, F1> ExprFFallibleVisitor<'a, Expr<E>, Expr<E>, E, E>
     for &'b mut ResolveVisitor<F1>
 where
-    F1: FnMut(&Import<Expr<E2>>) -> Result<E2, Err>,
+    E: Clone,
+    F1: FnMut(&Import<Expr<E>>) -> Result<E, Err>,
 {
     type Error = Err;
 
     fn visit_subexpr(
         &mut self,
         subexpr: &'a Expr<E>,
-    ) -> Result<Expr<E2>, Self::Error> {
+    ) -> Result<Expr<E>, Self::Error> {
         Ok(subexpr.rewrap(
             subexpr
                 .as_ref()
                 .traverse_resolve_with_visitor(&mut **self)?,
         ))
     }
-    fn visit_embed(self, _embed: &'a E) -> Result<E2, Self::Error> {
-        unimplemented!()
+    fn visit_embed(self, embed: &'a E) -> Result<E, Self::Error> {
+        Ok(embed.clone())
     }
 }


### PR DESCRIPTION
This is more elegant (and performant) than reconstructing the entire tree when resolving.