### PR TITLE
Add basic pretty type errors to all errors

### DIFF
--- a/dhall/src/error/mod.rs
+++ b/dhall/src/error/mod.rs
@@ -47,42 +47,7 @@ pub struct TypeError {
 /// The specific type error
 #[derive(Debug)]
 pub(crate) enum TypeMessage {
-    // UnboundVariable(Span),
-    // NotAFunction(Value),
-    // TypeMismatch(Value, Value, Value),
-    // AnnotMismatch(Value, Value),
-    // InvalidListElement(usize, Value, Value),
-    // InvalidListType(Value),
-    // InvalidOptionalType(Value),
-    // InvalidPredicate(Value),
-    // IfBranchMismatch(Value, Value),
-    // IfBranchMustBeTerm(bool, Value),
-    // InvalidFieldType(Label, Value),
-    // NotARecord(Label, Value),
-    // MustCombineRecord(Value),
-    // MissingRecordField(Label, Value),
-    // MissingUnionField(Label, Value),
-    // BinOpTypeMismatch(BinOp, Value),
-    // InvalidTextInterpolation(Value),
-    // Merge1ArgMustBeRecord(Value),
-    // Merge2ArgMustBeUnionOrOptional(Value),
-    // MergeEmptyNeedsAnnotation,
-    // MergeHandlerMissingVariant(Label),
-    // MergeVariantMissingHandler(Label),
-    // MergeAnnotMismatch,
-    // MergeHandlerTypeMismatch,
-    // MergeHandlerReturnTypeMustNotBeDependent,
-    // ProjectionMustBeRecord,
-    // ProjectionMissingEntry,
-    // ProjectionDuplicateField,
     Sort,
-    // RecordTypeDuplicateField,
-    // RecordTypeMergeRequiresRecordType(Value),
-    // UnionTypeDuplicateField,
-    // EquivalenceArgumentMustBeTerm(bool, Value),
-    // EquivalenceTypeMismatch(Value, Value),
-    // AssertMismatch(Value, Value),
-    // AssertMustTakeEquivalence,
     Custom(String),
 }
 
@@ -96,24 +61,8 @@ impl std::fmt::Display for TypeError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         use TypeMessage::*;
         let msg = match &self.message {
-            // UnboundVariable(var) => var.error("Type error: Unbound variable"),
-            // NotAFunction(v) => v.span().error("Type error: Not a function"),
-            // TypeMismatch(x, y, z) => {
-            //     x.span()
-            //         .error("Type error: Wrong type of function argument")
-            //         + "\n"
-            //         + &z.span().error(format!(
-            //             "This argument has type {:?}",
-            //             z.get_type().unwrap()
-            //         ))
-            //         + "\n"
-            //         + &y.span().error(format!(
-            //             "But the function expected an argument of type {:?}",
-            //             y
-            //         ))
-            // }
-            Custom(s) => format!("Type error: Unhandled error: {}", s),
-            _ => format!("Type error: Unhandled error: {:?}", self.message),
+            Sort => format!("Type error: Unhandled error: {:?}", self.message),
+            Custom(s) => format!("Type error: {}", s),
         };
         write!(f, "{}", msg)
     }

--- a/dhall/src/syntax/ast/span.rs
+++ b/dhall/src/syntax/ast/span.rs
@@ -100,8 +100,10 @@ fn char_idx_from_byte_idx(input: &str, idx: usize) -> usize {
         .char_indices()
         .enumerate()
         .find(|(_, (i, _))| *i == idx)
-        .unwrap()
-        .0;
+        .map(|(i, (_, _))| i)
+        // We should be able to unwrap() here, but somehow it panics on an example from
+        // serde_dhall/lib.rs...
+        .unwrap_or(0);
     // Unix-style newlines are counted as two chars (see
     // https://github.com/rust-lang/annotate-snippets-rs/issues/24).
     let nbr_newlines = input[..idx].chars().filter(|c| *c == '\n').count();

--- a/dhall/tests/type-errors/hurkensParadox.txt
+++ b/dhall/tests/type-errors/hurkensParadox.txt
@@ -1,4 +1,4 @@
-Type error: Unhandled error: error: wrong type of function argument
+Type error: error: wrong type of function argument
   --> <current file>:6:23
    |
  1 |     let bottom : Type = ∀(any : Type) → any

--- a/dhall/tests/type-errors/mixedUnions.txt
+++ b/dhall/tests/type-errors/mixedUnions.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: InvalidFieldType
+Type error: error: InvalidFieldType
+ --> <current file>:1:0
+  |
+1 | < Left : Natural | Right : Type >
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ InvalidFieldType
+  |

--- a/dhall/tests/type-errors/unit/AnnotationRecordWrongFieldName.txt
+++ b/dhall/tests/type-errors/unit/AnnotationRecordWrongFieldName.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: annot mismatch: ({ x = 1 } : { x : Natural }) : { y : Natural }
+Type error: error: annot mismatch: ({ x = 1 } : { x : Natural }) : { y : Natural }
+ --> <current file>:1:0
+  |
+1 | { x = 1 } : { y : Natural }
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ annot mismatch: ({ x = 1 } : { x : Natural }) : { y : Natural }
+  |

--- a/dhall/tests/type-errors/unit/AnnotationRecordWrongFieldType.txt
+++ b/dhall/tests/type-errors/unit/AnnotationRecordWrongFieldType.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: annot mismatch: ({ x = 1 } : { x : Natural }) : { x : Text }
+Type error: error: annot mismatch: ({ x = 1 } : { x : Natural }) : { x : Text }
+ --> <current file>:1:0
+  |
+1 | { x = 1 } : { x : Text }
+  | ^^^^^^^^^^^^^^^^^^^^^^^^ annot mismatch: ({ x = 1 } : { x : Natural }) : { x : Text }
+  |

--- a/dhall/tests/type-errors/unit/AssertAlphaTrap.txt
+++ b/dhall/tests/type-errors/unit/AssertAlphaTrap.txt
@@ -1,4 +1,4 @@
-Type error: Unhandled error: error: unbound variable ``_``
+Type error: error: unbound variable ``_``
  --> <current file>:1:46
   |
 1 | assert : (\(_: Bool) -> _) === (\(x: Bool) -> _)

--- a/dhall/tests/type-errors/unit/AssertDoubleZeros.txt
+++ b/dhall/tests/type-errors/unit/AssertDoubleZeros.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: AssertMismatch
+Type error: error: AssertMismatch
+ --> <current file>:1:0
+  |
+1 | assert : -0.0 ≡ +0.0
+  | ^^^^^^^^^^^^^^^^^^^^ AssertMismatch
+  |

--- a/dhall/tests/type-errors/unit/AssertNotEquivalence.txt
+++ b/dhall/tests/type-errors/unit/AssertNotEquivalence.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: AssertMustTakeEquivalence
+Type error: error: AssertMustTakeEquivalence
+ --> <current file>:1:0
+  |
+1 | assert : Bool
+  | ^^^^^^^^^^^^^ AssertMustTakeEquivalence
+  |

--- a/dhall/tests/type-errors/unit/AssertTriviallyFalse.txt
+++ b/dhall/tests/type-errors/unit/AssertTriviallyFalse.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: AssertMismatch
+Type error: error: AssertMismatch
+ --> <current file>:1:0
+  |
+1 | assert : 1 === 2
+  | ^^^^^^^^^^^^^^^^ AssertMismatch
+  |

--- a/dhall/tests/type-errors/unit/EquivalenceNotSameType.txt
+++ b/dhall/tests/type-errors/unit/EquivalenceNotSameType.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: EquivalenceTypeMismatch
+Type error: error: EquivalenceTypeMismatch
+ --> <current file>:1:0
+  |
+1 | 1 === False
+  | ^^^^^^^^^^^ EquivalenceTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/EquivalenceNotTerms.txt
+++ b/dhall/tests/type-errors/unit/EquivalenceNotTerms.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: EquivalenceArgumentsMustBeTerms
+Type error: error: EquivalenceArgumentsMustBeTerms
+ --> <current file>:1:0
+  |
+1 | Bool === Bool
+  | ^^^^^^^^^^^^^ EquivalenceArgumentsMustBeTerms
+  |

--- a/dhall/tests/type-errors/unit/FunctionApplicationArgumentNotMatch.txt
+++ b/dhall/tests/type-errors/unit/FunctionApplicationArgumentNotMatch.txt
@@ -1,4 +1,4 @@
-Type error: Unhandled error: error: wrong type of function argument
+Type error: error: wrong type of function argument
  --> <current file>:1:1
   |
 1 | (λ(_ : Natural) → _) True

--- a/dhall/tests/type-errors/unit/FunctionApplicationIsNotFunction.txt
+++ b/dhall/tests/type-errors/unit/FunctionApplicationIsNotFunction.txt
@@ -1,4 +1,4 @@
-Type error: Unhandled error: error: expected function, found `Bool`
+Type error: error: expected function, found `Bool`
  --> <current file>:1:0
   |
 1 | True True

--- a/dhall/tests/type-errors/unit/FunctionArgumentTypeNotAType.txt
+++ b/dhall/tests/type-errors/unit/FunctionArgumentTypeNotAType.txt
@@ -1,4 +1,4 @@
-Type error: Unhandled error: error: Invalid input type: `Natural`
+Type error: error: Invalid input type: `Natural`
  --> <current file>:1:6
   |
 1 | λ(_ : 1) → _

--- a/dhall/tests/type-errors/unit/FunctionTypeArgumentTypeNotAType.txt
+++ b/dhall/tests/type-errors/unit/FunctionTypeArgumentTypeNotAType.txt
@@ -1,4 +1,4 @@
-Type error: Unhandled error: error: Invalid input type: `Natural`
+Type error: error: Invalid input type: `Natural`
  --> <current file>:1:0
   |
 1 | 2 → _

--- a/dhall/tests/type-errors/unit/IfBranchesNotMatch.txt
+++ b/dhall/tests/type-errors/unit/IfBranchesNotMatch.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: IfBranchMismatch
+Type error: error: IfBranchMismatch
+ --> <current file>:1:0
+  |
+1 | if True then 1 else ""
+  | ^^^^^^^^^^^^^^^^^^^^^^ IfBranchMismatch
+  |

--- a/dhall/tests/type-errors/unit/IfBranchesNotType.txt
+++ b/dhall/tests/type-errors/unit/IfBranchesNotType.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: IfBranchMustBeTerm
+Type error: error: IfBranchMustBeTerm
+ --> <current file>:1:0
+  |
+1 | if True then Type else Type
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ IfBranchMustBeTerm
+  |

--- a/dhall/tests/type-errors/unit/IfNotBool.txt
+++ b/dhall/tests/type-errors/unit/IfNotBool.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: InvalidPredicate
+Type error: error: InvalidPredicate
+ --> <current file>:1:0
+  |
+1 | if 1 then 1 else 1
+  | ^^^^^^^^^^^^^^^^^^ InvalidPredicate
+  |

--- a/dhall/tests/type-errors/unit/LetWithWrongAnnotation.txt
+++ b/dhall/tests/type-errors/unit/LetWithWrongAnnotation.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: annot mismatch: (True : Bool) : Natural
+Type error: error: annot mismatch: (True : Bool) : Natural
+ --> <current file>:1:8
+  |
+1 | let x : Natural = True in True
+  |         ^^^^^^^ annot mismatch: (True : Bool) : Natural
+  |

--- a/dhall/tests/type-errors/unit/ListLiteralEmptyNotType.txt
+++ b/dhall/tests/type-errors/unit/ListLiteralEmptyNotType.txt
@@ -1,4 +1,4 @@
-Type error: Unhandled error: error: wrong type of function argument
+Type error: error: wrong type of function argument
  --> <current file>:1:5
   |
 1 | [] : List Type

--- a/dhall/tests/type-errors/unit/ListLiteralNotType.txt
+++ b/dhall/tests/type-errors/unit/ListLiteralNotType.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: InvalidListType
+Type error: error: InvalidListType
+ --> <current file>:1:0
+  |
+1 | [ Bool ]
+  | ^^^^^^^^ InvalidListType
+  |

--- a/dhall/tests/type-errors/unit/ListLiteralTypesNotMatch.txt
+++ b/dhall/tests/type-errors/unit/ListLiteralTypesNotMatch.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: InvalidListElement
+Type error: error: InvalidListElement
+ --> <current file>:1:0
+  |
+1 | [ True, 1 ]
+  | ^^^^^^^^^^^ InvalidListElement
+  |

--- a/dhall/tests/type-errors/unit/MergeAlternativeHasNoHandler.txt
+++ b/dhall/tests/type-errors/unit/MergeAlternativeHasNoHandler.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: MergeVariantMissingHandler
+Type error: error: MergeVariantMissingHandler
+ --> <current file>:1:0
+  |
+1 | merge {=} (< x : Bool >.x True)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ MergeVariantMissingHandler
+  |

--- a/dhall/tests/type-errors/unit/MergeAnnotationMismatch.txt
+++ b/dhall/tests/type-errors/unit/MergeAnnotationMismatch.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: MergeAnnotMismatch
+Type error: error: MergeAnnotMismatch
+ --> <current file>:1:0
+  |
+1 | merge { x = 0 } < x >.x : Bool
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ MergeAnnotMismatch
+  |

--- a/dhall/tests/type-errors/unit/MergeAnnotationNotType.txt
+++ b/dhall/tests/type-errors/unit/MergeAnnotationNotType.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: Merge2ArgMustBeUnionOrOptional
+Type error: error: Merge2ArgMustBeUnionOrOptional
+ --> <current file>:1:0
+  |
+1 | merge {=} <> : Type
+  | ^^^^^^^^^^^^^^^^^^^ Merge2ArgMustBeUnionOrOptional
+  |

--- a/dhall/tests/type-errors/unit/MergeEmptyNeedsDirectAnnotation1.txt
+++ b/dhall/tests/type-errors/unit/MergeEmptyNeedsDirectAnnotation1.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: MergeEmptyNeedsAnnotation
+Type error: error: MergeEmptyNeedsAnnotation
+ --> <current file>:1:13
+  |
+1 | \(x: <>) -> (merge {=} x) : Bool
+  |              ^^^^^^^^^^^ MergeEmptyNeedsAnnotation
+  |

--- a/dhall/tests/type-errors/unit/MergeEmptyNeedsDirectAnnotation2.txt
+++ b/dhall/tests/type-errors/unit/MergeEmptyNeedsDirectAnnotation2.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: MergeEmptyNeedsAnnotation
+Type error: error: MergeEmptyNeedsAnnotation
+ --> <current file>:1:26
+  |
+1 | \(x: <>) -> let y: Bool = merge {=} x in 1
+  |                           ^^^^^^^^^^^ MergeEmptyNeedsAnnotation
+  |

--- a/dhall/tests/type-errors/unit/MergeEmptyWithoutAnnotation.txt
+++ b/dhall/tests/type-errors/unit/MergeEmptyWithoutAnnotation.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: Merge2ArgMustBeUnionOrOptional
+Type error: error: Merge2ArgMustBeUnionOrOptional
+ --> <current file>:1:0
+  |
+1 | merge {=} <>
+  | ^^^^^^^^^^^^ Merge2ArgMustBeUnionOrOptional
+  |

--- a/dhall/tests/type-errors/unit/MergeHandlerNotFunction.txt
+++ b/dhall/tests/type-errors/unit/MergeHandlerNotFunction.txt
@@ -1,4 +1,4 @@
-Type error: Unhandled error: error: merge handler is not a function
+Type error: error: merge handler is not a function
  --> <current file>:1:0
   |
 1 | merge { x = True } (< x : Bool >.x True)

--- a/dhall/tests/type-errors/unit/MergeHandlerNotInUnion.txt
+++ b/dhall/tests/type-errors/unit/MergeHandlerNotInUnion.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: Merge2ArgMustBeUnionOrOptional
+Type error: error: Merge2ArgMustBeUnionOrOptional
+ --> <current file>:1:0
+  |
+1 | merge { x = λ(_ : Bool) → _ } <> : Bool
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Merge2ArgMustBeUnionOrOptional
+  |

--- a/dhall/tests/type-errors/unit/MergeHandlerNotMatchAlternativeType.txt
+++ b/dhall/tests/type-errors/unit/MergeHandlerNotMatchAlternativeType.txt
@@ -1,4 +1,4 @@
-Type error: Unhandled error: error: Wrong handler input type
+Type error: error: Wrong handler input type
  --> <current file>:1:0
   |
 1 | merge { x = λ(_ : Bool) → _ } (< x : Natural >.x 1)

--- a/dhall/tests/type-errors/unit/MergeHandlersWithDifferentType.txt
+++ b/dhall/tests/type-errors/unit/MergeHandlersWithDifferentType.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: MergeHandlerTypeMismatch
+Type error: error: MergeHandlerTypeMismatch
+ --> <current file>:1:0
+  |
+1 | merge { x = λ(_ : Bool) → _, y = λ(_ : Natural) → _ } (< x : Bool | y : Natural >.x True)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ MergeHandlerTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/MergeLhsNotRecord.txt
+++ b/dhall/tests/type-errors/unit/MergeLhsNotRecord.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: Merge1ArgMustBeRecord
+Type error: error: Merge1ArgMustBeRecord
+ --> <current file>:1:0
+  |
+1 | merge True < x >.x
+  | ^^^^^^^^^^^^^^^^^^ Merge1ArgMustBeRecord
+  |

--- a/dhall/tests/type-errors/unit/MergeMissingHandler1.txt
+++ b/dhall/tests/type-errors/unit/MergeMissingHandler1.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: MergeVariantMissingHandler
+Type error: error: MergeVariantMissingHandler
+ --> <current file>:1:0
+  |
+1 | merge {=} <x>.x
+  | ^^^^^^^^^^^^^^^ MergeVariantMissingHandler
+  |

--- a/dhall/tests/type-errors/unit/MergeMissingHandler2.txt
+++ b/dhall/tests/type-errors/unit/MergeMissingHandler2.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: MergeVariantMissingHandler
+Type error: error: MergeVariantMissingHandler
+ --> <current file>:1:0
+  |
+1 | merge { x = 0 } <x | y>.x
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^ MergeVariantMissingHandler
+  |

--- a/dhall/tests/type-errors/unit/MergeRhsNotUnion.txt
+++ b/dhall/tests/type-errors/unit/MergeRhsNotUnion.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: Merge2ArgMustBeUnionOrOptional
+Type error: error: Merge2ArgMustBeUnionOrOptional
+ --> <current file>:1:0
+  |
+1 | merge {=} True
+  | ^^^^^^^^^^^^^^ Merge2ArgMustBeUnionOrOptional
+  |

--- a/dhall/tests/type-errors/unit/MergeUnusedHandler.txt
+++ b/dhall/tests/type-errors/unit/MergeUnusedHandler.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: MergeHandlerMissingVariant
+Type error: error: MergeHandlerMissingVariant
+ --> <current file>:1:0
+  |
+1 | merge { x = 1, y = 2 } < x >.x
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ MergeHandlerMissingVariant
+  |

--- a/dhall/tests/type-errors/unit/NaturalSubtractNotNatural.txt
+++ b/dhall/tests/type-errors/unit/NaturalSubtractNotNatural.txt
@@ -1,4 +1,4 @@
-Type error: Unhandled error: error: wrong type of function argument
+Type error: error: wrong type of function argument
  --> <current file>:1:0
   |
 1 | Natural/subtract True True

--- a/dhall/tests/type-errors/unit/OperatorAndNotBool.txt
+++ b/dhall/tests/type-errors/unit/OperatorAndNotBool.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: BinOpTypeMismatch
+Type error: error: BinOpTypeMismatch
+ --> <current file>:1:0
+  |
+1 | 1 && 1
+  | ^^^^^^ BinOpTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/OperatorEqualNotBool.txt
+++ b/dhall/tests/type-errors/unit/OperatorEqualNotBool.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: BinOpTypeMismatch
+Type error: error: BinOpTypeMismatch
+ --> <current file>:1:0
+  |
+1 | 1 == 1
+  | ^^^^^^ BinOpTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/OperatorListConcatenateLhsNotList.txt
+++ b/dhall/tests/type-errors/unit/OperatorListConcatenateLhsNotList.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: BinOpTypeMismatch
+Type error: error: BinOpTypeMismatch
+ --> <current file>:1:0
+  |
+1 | 1 # [ True ]
+  | ^^^^^^^^^^^^ BinOpTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/OperatorListConcatenateListsNotMatch.txt
+++ b/dhall/tests/type-errors/unit/OperatorListConcatenateListsNotMatch.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: BinOpTypeMismatch
+Type error: error: BinOpTypeMismatch
+ --> <current file>:1:0
+  |
+1 | [ True ] # [ 1 ]
+  | ^^^^^^^^^^^^^^^^ BinOpTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/OperatorListConcatenateNotListsButMatch.txt
+++ b/dhall/tests/type-errors/unit/OperatorListConcatenateNotListsButMatch.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: BinOpTypeMismatch
+Type error: error: BinOpTypeMismatch
+ --> <current file>:1:0
+  |
+1 | 1 # 2
+  | ^^^^^ BinOpTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/OperatorListConcatenateRhsNotList.txt
+++ b/dhall/tests/type-errors/unit/OperatorListConcatenateRhsNotList.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: BinOpTypeMismatch
+Type error: error: BinOpTypeMismatch
+ --> <current file>:1:0
+  |
+1 | [ True ] # 1
+  | ^^^^^^^^^^^^ BinOpTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/OperatorNotEqualNotBool.txt
+++ b/dhall/tests/type-errors/unit/OperatorNotEqualNotBool.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: BinOpTypeMismatch
+Type error: error: BinOpTypeMismatch
+ --> <current file>:1:0
+  |
+1 | 1 != 1
+  | ^^^^^^ BinOpTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/OperatorOrNotBool.txt
+++ b/dhall/tests/type-errors/unit/OperatorOrNotBool.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: BinOpTypeMismatch
+Type error: error: BinOpTypeMismatch
+ --> <current file>:1:0
+  |
+1 | 1 || 1
+  | ^^^^^^ BinOpTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/OperatorPlusNotNatural.txt
+++ b/dhall/tests/type-errors/unit/OperatorPlusNotNatural.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: BinOpTypeMismatch
+Type error: error: BinOpTypeMismatch
+ --> <current file>:1:0
+  |
+1 | True + True
+  | ^^^^^^^^^^^ BinOpTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/OperatorTextConcatenateLhsNotText.txt
+++ b/dhall/tests/type-errors/unit/OperatorTextConcatenateLhsNotText.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: BinOpTypeMismatch
+Type error: error: BinOpTypeMismatch
+ --> <current file>:1:0
+  |
+1 | 1 ++ ""
+  | ^^^^^^^ BinOpTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/OperatorTextConcatenateRhsNotText.txt
+++ b/dhall/tests/type-errors/unit/OperatorTextConcatenateRhsNotText.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: BinOpTypeMismatch
+Type error: error: BinOpTypeMismatch
+ --> <current file>:1:0
+  |
+1 | "" ++ 1
+  | ^^^^^^^ BinOpTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/OperatorTimesNotNatural.txt
+++ b/dhall/tests/type-errors/unit/OperatorTimesNotNatural.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: BinOpTypeMismatch
+Type error: error: BinOpTypeMismatch
+ --> <current file>:1:0
+  |
+1 | True * True
+  | ^^^^^^^^^^^ BinOpTypeMismatch
+  |

--- a/dhall/tests/type-errors/unit/OptionalDeprecatedSyntaxAbsent.txt
+++ b/dhall/tests/type-errors/unit/OptionalDeprecatedSyntaxAbsent.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: InvalidListType
+Type error: error: InvalidListType
+ --> <current file>:1:0
+  |
+1 | [] : Optional Bool
+  | ^^^^^^^^^^^^^^^^^^ InvalidListType
+  |

--- a/dhall/tests/type-errors/unit/OptionalDeprecatedSyntaxPresent.txt
+++ b/dhall/tests/type-errors/unit/OptionalDeprecatedSyntaxPresent.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: annot mismatch: ([1] : List Natural) : Optional Natural
+Type error: error: annot mismatch: ([1] : List Natural) : Optional Natural
+ --> <current file>:1:0
+  |
+1 | [ 1 ] : Optional Natural
+  | ^^^^^^^^^^^^^^^^^^^^^^^^ annot mismatch: ([1] : List Natural) : Optional Natural
+  |

--- a/dhall/tests/type-errors/unit/RecordLitDuplicateFields.txt
+++ b/dhall/tests/type-errors/unit/RecordLitDuplicateFields.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: RecordTypeDuplicateField
+Type error: error: RecordTypeDuplicateField
+ --> <current file>:1:0
+  |
+1 | { x = 0, x = 0 }
+  | ^^^^^^^^^^^^^^^^ RecordTypeDuplicateField
+  |

--- a/dhall/tests/type-errors/unit/RecordProjectionDuplicateFields.txt
+++ b/dhall/tests/type-errors/unit/RecordProjectionDuplicateFields.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: ProjectionDuplicateField
+Type error: error: ProjectionDuplicateField
+ --> <current file>:1:0
+  |
+1 | { x = 1 }.{ x, x }
+  | ^^^^^^^^^^^^^^^^^^ ProjectionDuplicateField
+  |

--- a/dhall/tests/type-errors/unit/RecordProjectionEmpty.txt
+++ b/dhall/tests/type-errors/unit/RecordProjectionEmpty.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: ProjectionMissingEntry
+Type error: error: ProjectionMissingEntry
+ --> <current file>:1:0
+  |
+1 | {=}.{ x }
+  | ^^^^^^^^^ ProjectionMissingEntry
+  |

--- a/dhall/tests/type-errors/unit/RecordProjectionNotPresent.txt
+++ b/dhall/tests/type-errors/unit/RecordProjectionNotPresent.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: ProjectionMissingEntry
+Type error: error: ProjectionMissingEntry
+ --> <current file>:1:0
+  |
+1 | { y = {=} }.{ x }
+  | ^^^^^^^^^^^^^^^^^ ProjectionMissingEntry
+  |

--- a/dhall/tests/type-errors/unit/RecordProjectionNotRecord.txt
+++ b/dhall/tests/type-errors/unit/RecordProjectionNotRecord.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: ProjectionMustBeRecord
+Type error: error: ProjectionMustBeRecord
+ --> <current file>:1:0
+  |
+1 | True.{ x }
+  | ^^^^^^^^^^ ProjectionMustBeRecord
+  |

--- a/dhall/tests/type-errors/unit/RecordSelectionEmpty.txt
+++ b/dhall/tests/type-errors/unit/RecordSelectionEmpty.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: MissingRecordField
+Type error: error: MissingRecordField
+ --> <current file>:1:0
+  |
+1 | {=}.x
+  | ^^^^^ MissingRecordField
+  |

--- a/dhall/tests/type-errors/unit/RecordSelectionNotPresent.txt
+++ b/dhall/tests/type-errors/unit/RecordSelectionNotPresent.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: MissingRecordField
+Type error: error: MissingRecordField
+ --> <current file>:1:0
+  |
+1 | { y = {=} }.x
+  | ^^^^^^^^^^^^^ MissingRecordField
+  |

--- a/dhall/tests/type-errors/unit/RecordSelectionNotRecord.txt
+++ b/dhall/tests/type-errors/unit/RecordSelectionNotRecord.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: NotARecord
+Type error: error: NotARecord
+ --> <current file>:1:0
+  |
+1 | True.x
+  | ^^^^^^ NotARecord
+  |

--- a/dhall/tests/type-errors/unit/RecordSelectionTypeNotUnionType.txt
+++ b/dhall/tests/type-errors/unit/RecordSelectionTypeNotUnionType.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: NotARecord
+Type error: error: NotARecord
+ --> <current file>:1:0
+  |
+1 | Bool.x
+  | ^^^^^^ NotARecord
+  |

--- a/dhall/tests/type-errors/unit/RecordTypeDuplicateFields.txt
+++ b/dhall/tests/type-errors/unit/RecordTypeDuplicateFields.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: RecordTypeDuplicateField
+Type error: error: RecordTypeDuplicateField
+ --> <current file>:1:0
+  |
+1 | { x: Natural, x: Natural }
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ RecordTypeDuplicateField
+  |

--- a/dhall/tests/type-errors/unit/RecordTypeValueMember.txt
+++ b/dhall/tests/type-errors/unit/RecordTypeValueMember.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: InvalidFieldType
+Type error: error: InvalidFieldType
+ --> <current file>:1:0
+  |
+1 | { x : True }
+  | ^^^^^^^^^^^^ InvalidFieldType
+  |

--- a/dhall/tests/type-errors/unit/RecursiveRecordMergeLhsNotRecord.txt
+++ b/dhall/tests/type-errors/unit/RecursiveRecordMergeLhsNotRecord.txt
@@ -1,1 +1,1 @@
-Type error: Unhandled error: RecordTypeMergeRequiresRecordType
+Type error: error: RecordTypeMergeRequiresRecordType

--- a/dhall/tests/type-errors/unit/RecursiveRecordMergeOverlapping.txt
+++ b/dhall/tests/type-errors/unit/RecursiveRecordMergeOverlapping.txt
@@ -1,1 +1,1 @@
-Type error: Unhandled error: RecordTypeMergeRequiresRecordType
+Type error: error: RecordTypeMergeRequiresRecordType

--- a/dhall/tests/type-errors/unit/RecursiveRecordMergeRhsNotRecord.txt
+++ b/dhall/tests/type-errors/unit/RecursiveRecordMergeRhsNotRecord.txt
@@ -1,1 +1,1 @@
-Type error: Unhandled error: RecordTypeMergeRequiresRecordType
+Type error: error: RecordTypeMergeRequiresRecordType

--- a/dhall/tests/type-errors/unit/RecursiveRecordTypeMergeLhsNotRecordType.txt
+++ b/dhall/tests/type-errors/unit/RecursiveRecordTypeMergeLhsNotRecordType.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: RecordTypeMergeRequiresRecordType
+Type error: error: RecordTypeMergeRequiresRecordType
+ --> <current file>:1:0
+  |
+1 | Bool ⩓ {}
+  | ^^^^^^^^^ RecordTypeMergeRequiresRecordType
+  |

--- a/dhall/tests/type-errors/unit/RecursiveRecordTypeMergeOverlapping.txt
+++ b/dhall/tests/type-errors/unit/RecursiveRecordTypeMergeOverlapping.txt
@@ -1,1 +1,1 @@
-Type error: Unhandled error: RecordTypeMergeRequiresRecordType
+Type error: error: RecordTypeMergeRequiresRecordType

--- a/dhall/tests/type-errors/unit/RecursiveRecordTypeMergeRhsNotRecordType.txt
+++ b/dhall/tests/type-errors/unit/RecursiveRecordTypeMergeRhsNotRecordType.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: RecordTypeMergeRequiresRecordType
+Type error: error: RecordTypeMergeRequiresRecordType
+ --> <current file>:1:0
+  |
+1 | {} ⩓ Bool
+  | ^^^^^^^^^ RecordTypeMergeRequiresRecordType
+  |

--- a/dhall/tests/type-errors/unit/RightBiasedRecordMergeLhsNotRecord.txt
+++ b/dhall/tests/type-errors/unit/RightBiasedRecordMergeLhsNotRecord.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: MustCombineRecord
+Type error: error: MustCombineRecord
+ --> <current file>:1:0
+  |
+1 | True ⫽ {=}
+  | ^^^^^^^^^^ MustCombineRecord
+  |

--- a/dhall/tests/type-errors/unit/RightBiasedRecordMergeRhsNotRecord.txt
+++ b/dhall/tests/type-errors/unit/RightBiasedRecordMergeRhsNotRecord.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: MustCombineRecord
+Type error: error: MustCombineRecord
+ --> <current file>:1:0
+  |
+1 | {=} ⫽ True
+  | ^^^^^^^^^^ MustCombineRecord
+  |

--- a/dhall/tests/type-errors/unit/SomeNotType.txt
+++ b/dhall/tests/type-errors/unit/SomeNotType.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: InvalidOptionalType
+Type error: error: InvalidOptionalType
+ --> <current file>:1:0
+  |
+1 | Some Bool
+  | ^^^^^^^^^ InvalidOptionalType
+  |

--- a/dhall/tests/type-errors/unit/TextLiteralInterpolateNotText.txt
+++ b/dhall/tests/type-errors/unit/TextLiteralInterpolateNotText.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: InvalidTextInterpolation
+Type error: error: InvalidTextInterpolation
+ --> <current file>:1:0
+  |
+1 | "${1}"
+  | ^^^^^^ InvalidTextInterpolation
+  |

--- a/dhall/tests/type-errors/unit/TypeAnnotationWrong.txt
+++ b/dhall/tests/type-errors/unit/TypeAnnotationWrong.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: annot mismatch: (1 : Natural) : Bool
+Type error: error: annot mismatch: (1 : Natural) : Bool
+ --> <current file>:1:0
+  |
+1 | 1 : Bool
+  | ^^^^^^^^ annot mismatch: (1 : Natural) : Bool
+  |

--- a/dhall/tests/type-errors/unit/UnionConstructorFieldNotPresent.txt
+++ b/dhall/tests/type-errors/unit/UnionConstructorFieldNotPresent.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: MissingUnionField
+Type error: error: MissingUnionField
+ --> <current file>:1:0
+  |
+1 | < x : Bool >.y
+  | ^^^^^^^^^^^^^^ MissingUnionField
+  |

--- a/dhall/tests/type-errors/unit/UnionDeprecatedConstructorsKeyword.txt
+++ b/dhall/tests/type-errors/unit/UnionDeprecatedConstructorsKeyword.txt
@@ -1,4 +1,4 @@
-Type error: Unhandled error: error: unbound variable `constructors`
+Type error: error: unbound variable `constructors`
  --> <current file>:1:0
   |
 1 | constructors < Left : Natural | Right : Bool >

--- a/dhall/tests/type-errors/unit/UnionTypeDuplicateVariants1.txt
+++ b/dhall/tests/type-errors/unit/UnionTypeDuplicateVariants1.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: UnionTypeDuplicateField
+Type error: error: UnionTypeDuplicateField
+ --> <current file>:1:0
+  |
+1 | <x | x>
+  | ^^^^^^^ UnionTypeDuplicateField
+  |

--- a/dhall/tests/type-errors/unit/UnionTypeDuplicateVariants2.txt
+++ b/dhall/tests/type-errors/unit/UnionTypeDuplicateVariants2.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: UnionTypeDuplicateField
+Type error: error: UnionTypeDuplicateField
+ --> <current file>:1:0
+  |
+1 | <x | x: Natural>
+  | ^^^^^^^^^^^^^^^^ UnionTypeDuplicateField
+  |

--- a/dhall/tests/type-errors/unit/UnionTypeMixedKinds.txt
+++ b/dhall/tests/type-errors/unit/UnionTypeMixedKinds.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: InvalidFieldType
+Type error: error: InvalidFieldType
+ --> <current file>:1:0
+  |
+1 | < x : Bool | y : Type >
+  | ^^^^^^^^^^^^^^^^^^^^^^^ InvalidFieldType
+  |

--- a/dhall/tests/type-errors/unit/UnionTypeMixedKinds2.txt
+++ b/dhall/tests/type-errors/unit/UnionTypeMixedKinds2.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: InvalidFieldType
+Type error: error: InvalidFieldType
+ --> <current file>:1:0
+  |
+1 | < x : Kind | y : Type >
+  | ^^^^^^^^^^^^^^^^^^^^^^^ InvalidFieldType
+  |

--- a/dhall/tests/type-errors/unit/UnionTypeMixedKinds3.txt
+++ b/dhall/tests/type-errors/unit/UnionTypeMixedKinds3.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: InvalidFieldType
+Type error: error: InvalidFieldType
+ --> <current file>:1:0
+  |
+1 | < x : Kind | y : Bool >
+  | ^^^^^^^^^^^^^^^^^^^^^^^ InvalidFieldType
+  |

--- a/dhall/tests/type-errors/unit/UnionTypeNotType.txt
+++ b/dhall/tests/type-errors/unit/UnionTypeNotType.txt
@@ -1,1 +1,6 @@
-Type error: Unhandled error: InvalidFieldType
+Type error: error: InvalidFieldType
+ --> <current file>:1:0
+  |
+1 | < x : True >
+  | ^^^^^^^^^^^^ InvalidFieldType
+  |

--- a/dhall/tests/type-errors/unit/VariableFree.txt
+++ b/dhall/tests/type-errors/unit/VariableFree.txt
@@ -1,4 +1,4 @@
-Type error: Unhandled error: error: unbound variable `x`
+Type error: error: unbound variable `x`
  --> <current file>:1:0
   |
 1 | x


### PR DESCRIPTION
At least now type errors all point to a location in the source file. More work is needed to make them user-friendly though.