### PR TITLE
Record projection by expression

### DIFF
--- a/dhall/build.rs
+++ b/dhall/build.rs
@@ -281,13 +281,6 @@ fn generate_tests() -> std::io::Result<()> {
                 path == "simple/integerToDouble"
                     // Too slow
                     || path == "remoteSystems"
-                    // TODO: projection by expression
-                    || path == "unit/RecordProjectionByTypeEmpty"
-                    || path == "unit/RecordProjectionByTypeNonEmpty"
-                    || path == "unit/RecordProjectionByTypeNormalizeProjection"
-                    || path == "unit/RecordProjectionByTypeWithinFieldSelection"
-                    || path == "unit/RecursiveRecordMergeWithinFieldSelection1"
-                    || path == "unit/NestedRecordProjectionByType"
                     // TODO: fix Double/show
                     || path == "prelude/JSON/number/1"
                     // TODO: doesn't typecheck
@@ -298,8 +291,8 @@ fn generate_tests() -> std::io::Result<()> {
                     || path == "simplifications/rightBiasedMergeWithinRecordProjectionWithinFieldSelection1"
                     || path == "simplifications/rightBiasedMergeWithinRecursiveRecordMergeWithinFieldselection"
                     || path == "simplifications/issue661"
-                    || path == "unit/RecordProjectionWithinFieldSelection"
                     || path == "unit/RecursiveRecordMergeWithinFieldSelection0"
+                    || path == "unit/RecursiveRecordMergeWithinFieldSelection1"
                     || path == "unit/RecursiveRecordMergeWithinFieldSelection2"
                     || path == "unit/RecursiveRecordMergeWithinFieldSelection3"
             }),

--- a/dhall/src/syntax/ast/expr.rs
+++ b/dhall/src/syntax/ast/expr.rs
@@ -178,7 +178,7 @@ pub enum ExprKind<SubExpr> {
     Field(SubExpr, Label),
     ///  `e.{ x, y, z }`
     Projection(SubExpr, DupTreeSet<Label>),
-    ///  `e.(t)`
+    ///  `e.(s)`
     ProjectionByExpr(SubExpr, SubExpr),
     ///  `x::y`
     Completion(SubExpr, SubExpr),


### PR DESCRIPTION
This PR implements the normalization part of #94
It looks to me like the type checking part of this feature is already implemented.

I don't think I fully understand when `PartialExpr` is needed, so I might have missed some cases that aren't covered by the test suite.