### PR TITLE
Draft add cache to resolve

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "dhall-lang"]
 	path = dhall-lang
 	url = https://github.com/dhall-lang/dhall-lang
+    ignore = dirty

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "pest_generator 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/dhall/Cargo.toml
+++ b/dhall/Cargo.toml
@@ -29,6 +29,7 @@ url = "2.1"
 [dev-dependencies]
 pretty_assertions = "0.6.1"
 version-sync = "0.8"
+rand = "0.7"
 
 [build-dependencies]
 walkdir = "2"

--- a/dhall/build.rs
+++ b/dhall/build.rs
@@ -250,8 +250,6 @@ fn generate_tests() -> std::io::Result<()> {
             variant: "ImportSuccess",
             exclude_path: Rc::new(|path: &str| {
                 false
-                    // TODO: import hash
-                    || path == "hashFromCache"
                     // TODO: the standard does not respect https://tools.ietf.org/html/rfc3986#section-5.2
                     || path == "unit/asLocation/RemoteCanonicalize4"
                     // TODO: import headers

--- a/dhall/src/error/mod.rs
+++ b/dhall/src/error/mod.rs
@@ -62,7 +62,7 @@ pub enum TypeMessage {
 pub enum CacheError {
     MissingConfiguration,
     InitialisationError { cause: IOError },
-    CacheHashInvalid
+    CacheHashInvalid,
 }
 
 impl Error {

--- a/dhall/src/error/mod.rs
+++ b/dhall/src/error/mod.rs
@@ -22,6 +22,7 @@ pub enum ErrorKind {
     Encode(EncodeError),
     Resolve(ImportError),
     Typecheck(TypeError),
+    Cache(CacheError),
 }
 
 #[derive(Debug)]
@@ -55,6 +56,13 @@ pub struct TypeError {
 #[derive(Debug)]
 pub enum TypeMessage {
     Custom(String),
+}
+
+#[derive(Debug)]
+pub enum CacheError {
+    MissingConfiguration,
+    InitialisationError { cause: IOError },
+    CacheHashInvalid
 }
 
 impl Error {
@@ -93,6 +101,7 @@ impl std::fmt::Display for Error {
             ErrorKind::Encode(err) => write!(f, "{:?}", err),
             ErrorKind::Resolve(err) => write!(f, "{:?}", err),
             ErrorKind::Typecheck(err) => write!(f, "{}", err),
+            ErrorKind::Cache(err) => write!(f, "{:?}", err),
         }
     }
 }
@@ -136,5 +145,10 @@ impl From<ImportError> for Error {
 impl From<TypeError> for Error {
     fn from(err: TypeError) -> Error {
         ErrorKind::Typecheck(err).into()
+    }
+}
+impl From<CacheError> for Error {
+    fn from(err: CacheError) -> Error {
+        ErrorKind::Cache(err).into()
     }
 }

--- a/dhall/src/semantics/resolve/cache.rs
+++ b/dhall/src/semantics/resolve/cache.rs
@@ -1,0 +1,145 @@
+use std::env;
+use std::io::Write;
+use std::path::{PathBuf, Path};
+
+use crate::error::{CacheError, Error, ErrorKind};
+use crate::parse::parse_binary_file;
+use crate::semantics::{Import, TypedHir};
+use crate::syntax::Hash;
+use crate::syntax::{binary, Expr};
+use crate::Parsed;
+use std::fs::File;
+
+#[cfg(unix)]
+const ALTERNATE_ENV_VAR: &str = "HOME";
+
+#[cfg(windows)]
+const ALTERNATE_ENV_VAR: &str = "LOCALAPPDATA";
+
+fn alternate_env_var_cache_dir() -> Option<PathBuf> {
+    env::var(ALTERNATE_ENV_VAR)
+        .map(PathBuf::from)
+        .map(|env_dir| env_dir.join(".cache").join("dhall"))
+        .ok()
+}
+
+fn env_var_cache_dir() -> Option<PathBuf> {
+    env::var("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .map(|cache_home| cache_home.join("dhall"))
+        .ok()
+}
+
+fn load_cache_dir() -> Result<PathBuf, CacheError> {
+    env_var_cache_dir()
+        .or_else(alternate_env_var_cache_dir)
+        .ok_or(CacheError::MissingConfiguration)
+}
+
+pub struct Cache {
+    cache_dir: Option<PathBuf>,
+}
+
+impl Cache {
+    pub fn new() -> Cache {
+        // Should warn that we can't initialize cache on error
+        let cache_dir = load_cache_dir().and_then(|path| {
+            std::fs::create_dir_all(path.as_path())
+                .map(|_| path)
+                .map_err(|e| CacheError::InitialisationError { cause: e })
+        });
+        Cache {
+            cache_dir: cache_dir.ok(),
+        }
+    }
+}
+
+impl Cache {
+    fn cache_file(&self, import: &Import) -> Option<PathBuf> {
+        self.cache_dir.as_ref()
+            .and_then(|cache_dir| import.hash.as_ref().map(|hash| (cache_dir, hash)))
+            .map(|(cache_dir, hash)| cache_dir.join(cache_filename(hash)))
+    }
+
+    fn search_cache_file(&self, import: &Import) -> Option<PathBuf> {
+        self.cache_file(import)
+            .filter(|cache_file| cache_file.exists())
+    }
+
+    fn search_cache(&self, import: &Import) -> Option<Result<Parsed, Error>> {
+        self.search_cache_file(import)
+            .map(|cache_file| parse_binary_file(cache_file.as_path()))
+    }
+
+    // Side effect since we don't use the result
+    fn delete_cache(&self, import: &Import) {
+        self.search_cache_file(import)
+            .map(|cache_file| std::fs::remove_file(cache_file.as_path()));
+    }
+
+    // Side effect since we don't use the result
+    fn save_expr(&self, import: &Import, expr: &Expr) {
+        self.cache_file(import)
+            .map(|cache_file| {
+                save_expr(cache_file.as_path(), expr)
+            });
+    }
+
+    pub fn caching_import<F, R>(&self, import: &Import, fetcher: F, mut resolver: R) -> Result<TypedHir, Error>
+        where F: FnOnce() -> Result<Parsed, Error>,
+              R: FnMut(Parsed) -> Result<TypedHir, Error> {
+        // Lookup the cache
+        self.search_cache(import)
+            // On cache found
+            .and_then(|cache_result| {
+                // Try to resolve the cache imported content
+                match cache_result.and_then(|parsed| resolver(parsed))
+                    .and_then(|typed_hir| check_hash(import.hash.as_ref().unwrap(), typed_hir))
+                {
+                    // Cache content is invalid (can't be parsed / can't be resolved / content sha invalid )
+                    Err(_) => {
+                        // Delete cache file since it's invalid
+                        self.delete_cache(import);
+                        // Result as there were no cache
+                        None
+                    }
+                    // Cache valid
+                    r => {
+                        Some(r)
+                    }
+                }
+            }).unwrap_or_else(|| {
+            // Fetch and resolve as provided
+            let imported = fetcher().and_then(resolver);
+            // Save in cache the result if ok
+            let _ = imported.as_ref().map(|(hir, _)| self.save_expr(import, &hir.to_expr_noopts()));
+            imported
+        })
+    }
+}
+
+fn save_expr(file_path: &Path, expr: &Expr) -> Result<(), Error> {
+    File::create(file_path)?
+        .write_all(binary::encode(expr)?.as_slice())?;
+    Ok(())
+}
+
+fn check_hash(hash: &Hash, typed_hir: TypedHir) -> Result<TypedHir, Error> {
+    if hash.as_ref()[..] != typed_hir.0.to_expr_alpha().hash()?[..] {
+        Err(Error::new(ErrorKind::Cache(CacheError::CacheHashInvalid)))
+    } else {
+        Ok(typed_hir)
+    }
+}
+
+fn cache_filename<A: AsRef<[u8]>>(v: A) -> String {
+    format!("1220{}", hex::encode(v.as_ref()))
+}
+
+impl AsRef<[u8]> for Hash {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Hash::SHA256(sha) => sha.as_slice(),
+        }
+    }
+}

--- a/dhall/src/semantics/resolve/cache.rs
+++ b/dhall/src/semantics/resolve/cache.rs
@@ -8,8 +8,8 @@ use crate::semantics::{Import, TypedHir};
 use crate::syntax::Hash;
 use crate::syntax::{binary, Expr};
 use crate::Parsed;
-use std::fs::File;
 use std::env::VarError;
+use std::fs::File;
 
 #[cfg(unix)]
 const ALTERNATE_ENV_VAR: &str = "HOME";
@@ -17,21 +17,27 @@ const ALTERNATE_ENV_VAR: &str = "HOME";
 #[cfg(windows)]
 const ALTERNATE_ENV_VAR: &str = "LOCALAPPDATA";
 
-fn alternate_env_var_cache_dir(provider: impl Fn(&str) -> Result<String, VarError>) -> Option<PathBuf> {
+fn alternate_env_var_cache_dir(
+    provider: impl Fn(&str) -> Result<String, VarError>,
+) -> Option<PathBuf> {
     provider(ALTERNATE_ENV_VAR)
         .map(PathBuf::from)
         .map(|env_dir| env_dir.join(".cache").join("dhall"))
         .ok()
 }
 
-fn env_var_cache_dir(provider: impl Fn(&str) -> Result<String, VarError>) -> Option<PathBuf> {
+fn env_var_cache_dir(
+    provider: impl Fn(&str) -> Result<String, VarError>,
+) -> Option<PathBuf> {
     provider("XDG_CACHE_HOME")
         .map(PathBuf::from)
         .map(|cache_home| cache_home.join("dhall"))
         .ok()
 }
 
-fn load_cache_dir(provider: impl Fn(&str) -> Result<String, VarError> + Copy) -> Result<PathBuf, CacheError> {
+fn load_cache_dir(
+    provider: impl Fn(&str) -> Result<String, VarError> + Copy,
+) -> Result<PathBuf, CacheError> {
     env_var_cache_dir(provider)
         .or_else(|| alternate_env_var_cache_dir(provider))
         .ok_or(CacheError::MissingConfiguration)
@@ -43,7 +49,9 @@ pub struct Cache {
 }
 
 impl Cache {
-    fn new_with_provider(provider: impl Fn(&str) -> Result<String, VarError> + Copy) -> Cache {
+    fn new_with_provider(
+        provider: impl Fn(&str) -> Result<String, VarError> + Copy,
+    ) -> Cache {
         // Should warn that we can't initialize cache on error
         let cache_dir = load_cache_dir(provider).and_then(|path| {
             if !path.exists() {
@@ -164,18 +172,18 @@ impl AsRef<[u8]> for Hash {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::env::temp_dir;
-    use rand::Rng;
     use rand::distributions::Alphanumeric;
+    use rand::Rng;
+    use std::env::temp_dir;
 
     #[cfg(unix)]
     #[test]
     fn alternate_env_var_cache_dir_should_result_unix_folder_path() {
-        let actual = alternate_env_var_cache_dir(|_| Ok("/home/user".to_string()));
+        let actual =
+            alternate_env_var_cache_dir(|_| Ok("/home/user".to_string()));
         assert_eq!(actual, Some(PathBuf::from("/home/user/.cache/dhall")));
     }
 
@@ -187,8 +195,13 @@ mod test {
 
     #[test]
     fn env_var_cache_dir_should_result_xdg_cache_home() {
-        let actual = env_var_cache_dir(|_| Ok("/home/user/custom/path/for/cache".to_string()));
-        assert_eq!(actual, Some(PathBuf::from("/home/user/custom/path/for/cache/dhall")));
+        let actual = env_var_cache_dir(|_| {
+            Ok("/home/user/custom/path/for/cache".to_string())
+        });
+        assert_eq!(
+            actual,
+            Some(PathBuf::from("/home/user/custom/path/for/cache/dhall"))
+        );
     }
 
     #[test]
@@ -199,31 +212,30 @@ mod test {
 
     #[test]
     fn load_cache_dir_should_result_xdg_cache_first() {
-        let actual = load_cache_dir(
-            |var| match var {
-                "XDG_CACHE_HOME" => Ok("/home/user/custom".to_string()),
-                _ => Err(VarError::NotPresent)
-            }
-        );
+        let actual = load_cache_dir(|var| match var {
+            "XDG_CACHE_HOME" => Ok("/home/user/custom".to_string()),
+            _ => Err(VarError::NotPresent),
+        });
         assert_eq!(actual.unwrap(), PathBuf::from("/home/user/custom/dhall"));
     }
 
     #[cfg(unix)]
     #[test]
     fn load_cache_dir_should_result_alternate() {
-        let actual = load_cache_dir(|var|
-            match var {
-                ALTERNATE_ENV_VAR => Ok("/home/user".to_string()),
-                _ => Err(VarError::NotPresent)
-            }
-        );
+        let actual = load_cache_dir(|var| match var {
+            ALTERNATE_ENV_VAR => Ok("/home/user".to_string()),
+            _ => Err(VarError::NotPresent),
+        });
         assert_eq!(actual.unwrap(), PathBuf::from("/home/user/.cache/dhall"));
     }
 
     #[test]
     fn load_cache_dir_should_result_none() {
         let actual = load_cache_dir(|_| Err(VarError::NotPresent));
-        assert!(matches!(actual.unwrap_err(), CacheError::MissingConfiguration));
+        assert!(matches!(
+            actual.unwrap_err(),
+            CacheError::MissingConfiguration
+        ));
     }
 
     #[test]
@@ -236,8 +248,15 @@ mod test {
 
         std::fs::create_dir_all(dir.as_path()).unwrap();
 
-        let actual = Cache::new_with_provider(|_| Ok(dir.clone().to_str().map(String::from).unwrap()));
-        assert_eq!(actual, Cache{ cache_dir: Some(dir.join("dhall"))});
+        let actual = Cache::new_with_provider(|_| {
+            Ok(dir.clone().to_str().map(String::from).unwrap())
+        });
+        assert_eq!(
+            actual,
+            Cache {
+                cache_dir: Some(dir.join("dhall"))
+            }
+        );
         assert!(dir.join("dhall").exists());
         std::fs::remove_dir_all(dir.as_path()).unwrap();
     }
@@ -255,10 +274,15 @@ mod test {
 
         assert!(dir.join("dhall").exists());
 
-        let actual = Cache::new_with_provider(|_| Ok(dir.clone().to_str().map(String::from).unwrap()));
-        assert_eq!(actual, Cache{ cache_dir: Some(dir.join("dhall"))});
+        let actual = Cache::new_with_provider(|_| {
+            Ok(dir.clone().to_str().map(String::from).unwrap())
+        });
+        assert_eq!(
+            actual,
+            Cache {
+                cache_dir: Some(dir.join("dhall"))
+            }
+        );
         std::fs::remove_dir_all(dir.as_path()).unwrap();
     }
-
-
 }

--- a/dhall/src/semantics/resolve/cache.rs
+++ b/dhall/src/semantics/resolve/cache.rs
@@ -8,9 +8,9 @@ use crate::semantics::{Import, TypedHir};
 use crate::syntax::Hash;
 use crate::syntax::{binary, Expr};
 use crate::Parsed;
-use std::fs::File;
 use std::env::VarError;
 use std::ffi::OsStr;
+use std::fs::File;
 
 #[cfg(unix)]
 const ALTERNATE_ENV_VAR: &str = "HOME";
@@ -18,21 +18,27 @@ const ALTERNATE_ENV_VAR: &str = "HOME";
 #[cfg(windows)]
 const ALTERNATE_ENV_VAR: &str = "LOCALAPPDATA";
 
-fn alternate_env_var_cache_dir(provider: impl Fn(&str) -> Result<String, VarError>) -> Option<PathBuf> {
+fn alternate_env_var_cache_dir(
+    provider: impl Fn(&str) -> Result<String, VarError>,
+) -> Option<PathBuf> {
     provider(ALTERNATE_ENV_VAR)
         .map(PathBuf::from)
         .map(|env_dir| env_dir.join(".cache").join("dhall"))
         .ok()
 }
 
-fn env_var_cache_dir(provider: impl Fn(&str) -> Result<String, VarError>) -> Option<PathBuf> {
+fn env_var_cache_dir(
+    provider: impl Fn(&str) -> Result<String, VarError>,
+) -> Option<PathBuf> {
     provider("XDG_CACHE_HOME")
         .map(PathBuf::from)
         .map(|cache_home| cache_home.join("dhall"))
         .ok()
 }
 
-fn load_cache_dir(provider: impl Fn(&str) -> Result<String, VarError> + Copy) -> Result<PathBuf, CacheError> {
+fn load_cache_dir(
+    provider: impl Fn(&str) -> Result<String, VarError> + Copy,
+) -> Result<PathBuf, CacheError> {
     env_var_cache_dir(provider)
         .or_else(|| alternate_env_var_cache_dir(provider))
         .ok_or(CacheError::MissingConfiguration)
@@ -44,7 +50,9 @@ pub struct Cache {
 }
 
 impl Cache {
-    fn new_with_provider(provider: impl Fn(&str) -> Result<String, VarError> + Copy) -> Cache {
+    fn new_with_provider(
+        provider: impl Fn(&str) -> Result<String, VarError> + Copy,
+    ) -> Cache {
         // Should warn that we can't initialize cache on error
         let cache_dir = load_cache_dir(provider).and_then(|path| {
             if !path.exists() {
@@ -168,14 +176,15 @@ impl AsRef<[u8]> for Hash {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::env::temp_dir;
-    use rand::Rng;
     use rand::distributions::Alphanumeric;
+    use rand::Rng;
+    use std::env::temp_dir;
 
     #[cfg(unix)]
     #[test]
     fn alternate_env_var_cache_dir_should_result_unix_folder_path() {
-        let actual = alternate_env_var_cache_dir(|_| Ok("/home/user".to_string()));
+        let actual =
+            alternate_env_var_cache_dir(|_| Ok("/home/user".to_string()));
         assert_eq!(actual, Some(PathBuf::from("/home/user/.cache/dhall")));
     }
 
@@ -187,8 +196,13 @@ mod test {
 
     #[test]
     fn env_var_cache_dir_should_result_xdg_cache_home() {
-        let actual = env_var_cache_dir(|_| Ok("/home/user/custom/path/for/cache".to_string()));
-        assert_eq!(actual, Some(PathBuf::from("/home/user/custom/path/for/cache/dhall")));
+        let actual = env_var_cache_dir(|_| {
+            Ok("/home/user/custom/path/for/cache".to_string())
+        });
+        assert_eq!(
+            actual,
+            Some(PathBuf::from("/home/user/custom/path/for/cache/dhall"))
+        );
     }
 
     #[test]
@@ -199,31 +213,30 @@ mod test {
 
     #[test]
     fn load_cache_dir_should_result_xdg_cache_first() {
-        let actual = load_cache_dir(
-            |var| match var {
-                "XDG_CACHE_HOME" => Ok("/home/user/custom".to_string()),
-                _ => Err(VarError::NotPresent)
-            }
-        );
+        let actual = load_cache_dir(|var| match var {
+            "XDG_CACHE_HOME" => Ok("/home/user/custom".to_string()),
+            _ => Err(VarError::NotPresent),
+        });
         assert_eq!(actual.unwrap(), PathBuf::from("/home/user/custom/dhall"));
     }
 
     #[cfg(unix)]
     #[test]
     fn load_cache_dir_should_result_alternate() {
-        let actual = load_cache_dir(|var|
-            match var {
-                ALTERNATE_ENV_VAR => Ok("/home/user".to_string()),
-                _ => Err(VarError::NotPresent)
-            }
-        );
+        let actual = load_cache_dir(|var| match var {
+            ALTERNATE_ENV_VAR => Ok("/home/user".to_string()),
+            _ => Err(VarError::NotPresent),
+        });
         assert_eq!(actual.unwrap(), PathBuf::from("/home/user/.cache/dhall"));
     }
 
     #[test]
     fn load_cache_dir_should_result_none() {
         let actual = load_cache_dir(|_| Err(VarError::NotPresent));
-        assert!(matches!(actual.unwrap_err(), CacheError::MissingConfiguration));
+        assert!(matches!(
+            actual.unwrap_err(),
+            CacheError::MissingConfiguration
+        ));
     }
 
     #[test]
@@ -236,8 +249,15 @@ mod test {
 
         std::fs::create_dir_all(dir.as_path()).unwrap();
 
-        let actual = Cache::new_with_provider(|_| Ok(dir.clone().to_str().map(String::from).unwrap()));
-        assert_eq!(actual, Cache{ cache_dir: Some(dir.join("dhall"))});
+        let actual = Cache::new_with_provider(|_| {
+            Ok(dir.clone().to_str().map(String::from).unwrap())
+        });
+        assert_eq!(
+            actual,
+            Cache {
+                cache_dir: Some(dir.join("dhall"))
+            }
+        );
         assert!(dir.join("dhall").exists());
         std::fs::remove_dir_all(dir.as_path()).unwrap();
     }
@@ -255,10 +275,15 @@ mod test {
 
         assert!(dir.join("dhall").exists());
 
-        let actual = Cache::new_with_provider(|_| Ok(dir.clone().to_str().map(String::from).unwrap()));
-        assert_eq!(actual, Cache{ cache_dir: Some(dir.join("dhall"))});
+        let actual = Cache::new_with_provider(|_| {
+            Ok(dir.clone().to_str().map(String::from).unwrap())
+        });
+        assert_eq!(
+            actual,
+            Cache {
+                cache_dir: Some(dir.join("dhall"))
+            }
+        );
         std::fs::remove_dir_all(dir.as_path()).unwrap();
     }
-
-
 }

--- a/dhall/src/semantics/resolve/mod.rs
+++ b/dhall/src/semantics/resolve/mod.rs
@@ -1,6 +1,8 @@
+pub mod cache;
 pub mod env;
 pub mod hir;
 pub mod resolve;
+pub use cache::*;
 pub use env::*;
 pub use hir::*;
 pub use resolve::*;

--- a/dhall/src/semantics/resolve/resolve.rs
+++ b/dhall/src/semantics/resolve/resolve.rs
@@ -9,7 +9,7 @@ use crate::builtins::Builtin;
 use crate::error::ErrorBuilder;
 use crate::error::{Error, ImportError};
 use crate::operations::{BinOp, OpKind};
-use crate::semantics::{mkerr, Hir, HirKind, ImportEnv, NameEnv, Type};
+use crate::semantics::{mkerr, Cache, Hir, HirKind, ImportEnv, NameEnv, Type};
 use crate::syntax;
 use crate::syntax::{
     Expr, ExprKind, FilePath, FilePrefix, Hash, ImportMode, ImportTarget, Span,
@@ -209,6 +209,7 @@ fn make_aslocation_uniontype() -> Expr {
 
 fn resolve_one_import(
     env: &mut ImportEnv,
+    cache: &Cache,
     import: &Import,
     location: &ImportLocation,
     span: Span,
@@ -217,32 +218,37 @@ fn resolve_one_import(
     let location = location.chain(&import.location, do_sanity_check)?;
     env.handle_import(location.clone(), |env| match import.mode {
         ImportMode::Code => {
-            let parsed = location.fetch_dhall()?;
-            let typed = resolve_with_env(env, parsed)?.typecheck()?;
-            let hir = typed.normalize().to_hir();
-            let ty = typed.ty().clone();
-            match &import.hash {
-                Some(Hash::SHA256(hash)) => {
-                    let actual_hash = hir.to_expr_alpha().hash()?;
-                    if hash[..] != actual_hash[..] {
-                        mkerr(
-                            ErrorBuilder::new("hash mismatch")
-                                .span_err(span, "hash mismatch")
-                                .note(format!(
-                                    "Expected sha256:{}",
-                                    hex::encode(hash)
-                                ))
-                                .note(format!(
-                                    "Found    sha256:{}",
-                                    hex::encode(actual_hash)
-                                ))
-                                .format(),
-                        )?
+                let (hir, ty) = cache.caching_import(
+                    import,
+                    || location.fetch_dhall(),
+                    |parsed| {
+                        let typed = resolve_with_env(env, cache, parsed)?.typecheck()?;
+                        let hir = typed.normalize().to_hir();
+                        Ok((hir, typed.ty))
                     }
+                )?;
+                match &import.hash {
+                    Some(Hash::SHA256(hash)) => {
+                        let actual_hash = hir.to_expr_alpha().hash()?;
+                        if hash[..] != actual_hash[..] {
+                            mkerr(
+                                ErrorBuilder::new("hash mismatch")
+                                    .span_err(span, "hash mismatch")
+                                    .note(format!(
+                                        "Expected sha256:{}",
+                                        hex::encode(hash)
+                                    ))
+                                    .note(format!(
+                                        "Found    sha256:{}",
+                                        hex::encode(actual_hash)
+                                    ))
+                                    .format(),
+                            )?
+                        }
+                    }
+                    None => {}
                 }
-                None => {}
-            }
-            Ok((hir, ty))
+                Ok((hir, ty))
         }
         ImportMode::RawText => {
             let text = location.fetch_text()?;
@@ -346,19 +352,21 @@ fn traverse_resolve_expr(
 
 fn resolve_with_env(
     env: &mut ImportEnv,
+    cache: &Cache,
     parsed: Parsed,
 ) -> Result<Resolved, Error> {
     let Parsed(expr, location) = parsed;
     let resolved = traverse_resolve_expr(
         &mut NameEnv::new(),
         &expr,
-        &mut |import, span| resolve_one_import(env, &import, &location, span),
+        &mut |import, span| resolve_one_import(env, cache, &import, &location, span),
     )?;
     Ok(Resolved(resolved))
 }
 
 pub fn resolve(parsed: Parsed) -> Result<Resolved, Error> {
-    resolve_with_env(&mut ImportEnv::new(), parsed)
+    let cache = Cache::new();
+    resolve_with_env(&mut ImportEnv::new(), &cache, parsed)
 }
 
 pub fn skip_resolve_expr(expr: &Expr) -> Result<Hir, Error> {
@@ -387,7 +395,6 @@ impl Canonicalize for FilePath {
                 // ───────────────────────────────────────
                 // canonicalize(directory₀/.) = directory₁
                 "." => continue,
-
                 ".." => match file_path.last() {
                     // canonicalize(directory₀) = ε
                     // ────────────────────────────


### PR DESCRIPTION
Add cache to resolve as defined in [standard](https://github.com/dhall-lang/dhall-lang/blob/master/standard/imports.md)

Create a `Cache` that check env vars depending on os and create folder if needed.
On `resolve_one_import` it search in the cache folder if the import `hash` is available if cache and hash are available.
If it exist then resolve and noramlize it. Check that the hash from the cache match the requested cache, if not delete the file from the cache
If cache is missing or invalid load te import like before and try to save it if a hash for import is provided.

Todo :
 - [x] Error management
 - [x] Tests
 - [x] Cache concurrency write (delegated to file API)
 - [x] Validate SHA of loaded from cache (if not delete cache file and load normally)
 - [x] ~Print info as defined in standard~ Didn't find how to send warn during compilation and feel out of scope for this PR
 - [x] Unit test on cache

Rel: #135 