### PR TITLE
Make dhall-rust build on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,3 +78,33 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Run tests
         run: wasm-pack test serde_dhall --node
+
+  # Tests don't work because of path escaping shenanigans. I have a branch that
+  # will fix that but depends on https://github.com/LukasKalbertodt/libtest-mimic/pull/4
+  test_windows:
+    name: Build on windows
+    # name: Run tests on windows
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@master
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+      # - name: Run tests
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: test

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ same name as the corresponding test.
 
 #### [Unreleased]
 
+- Support building on Windows
 - Support building to wasm
 
 #### [0.5.2] - 2020-04-12

--- a/dhall/build.rs
+++ b/dhall/build.rs
@@ -157,7 +157,7 @@ fn make_test_module(
 }
 
 fn generate_tests() -> std::io::Result<()> {
-    // To force regeneration of the test list, `touch dhall-lang/standard/dhall.abnf`
+    // To force regeneration of the test list, `touch dhall/build.rs`
     let out_dir = env::var("OUT_DIR").unwrap();
 
     let parser_tests_path = Path::new(&out_dir).join("spec_tests.rs");
@@ -348,7 +348,7 @@ fn generate_tests() -> std::io::Result<()> {
 
 fn convert_abnf_to_pest() -> std::io::Result<()> {
     let out_dir = env::var("OUT_DIR").unwrap();
-    let abnf_path = "src/syntax/text/dhall.abnf";
+    let abnf_path = "../dhall-lang/standard/dhall.abnf";
     let visibility_path = "src/syntax/text/dhall.pest.visibility";
     let grammar_path = Path::new(&out_dir).join("dhall.pest");
     println!("cargo:rerun-if-changed={}", abnf_path);

--- a/dhall/src/syntax/text/dhall.abnf
+++ b/dhall/src/syntax/text/dhall.abnf
@@ -1,1 +1,0 @@
-../../../../dhall-lang/standard/dhall.abnf


### PR DESCRIPTION
Discovered in https://github.com/Nadrieril/dhall-rust/issues/166 that it didn't.