### PR TITLE
Make reqwest an optional dependency

### DIFF
--- a/dhall/Cargo.toml
+++ b/dhall/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2018"
 build = "build.rs"
 include = ["src/**/*", "README.md", "build.rs"]
 
+[features]
+default = [ "reqwest" ]
+
 [[test]]
 name = "spec"
 harness = false
@@ -33,7 +36,7 @@ url = "2.1"
 # Reqwest needs proper async support to work on wasm. So no remote imports on
 # wasm for now.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-reqwest = { version = "0.10", features = ["blocking"] }
+reqwest = { version = "0.10", features = ["blocking"], optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.28"

--- a/dhall/src/semantics/resolve/resolve.rs
+++ b/dhall/src/semantics/resolve/resolve.rs
@@ -197,9 +197,13 @@ fn mkexpr(kind: UnspannedExpr) -> Expr {
 }
 
 // TODO: error handling
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "reqwest"))]
 pub(crate) fn download_http_text(url: Url) -> Result<String, Error> {
     Ok(reqwest::blocking::get(url).unwrap().text().unwrap())
+}
+#[cfg(all(not(target_arch = "wasm32"), not(feature = "reqwest")))]
+pub(crate) fn download_http_text(_url: Url) -> Result<String, Error> {
+    panic!("Remote imports are disabled in this build of dhall-rust")
 }
 #[cfg(target_arch = "wasm32")]
 pub(crate) fn download_http_text(_url: Url) -> Result<String, Error> {


### PR DESCRIPTION
This adds a feature to the Cargo.toml to be able to control if dhall depends on reqwest.
This makes it possible to build dhall-rust for any arch (not just wasm32) without depending on reqwest.

To disable reqwest as a dependency, we can now use `default-features = false` when adding the dhall dependency.

Closes #169