### PR TITLE
Use u64/i64 instead of usize/isize for the main number types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### [Unreleased]
 
+- BREAKING CHANGE: use u64/i64 instead of usize/isize in `NumKind`
+
 #### [0.7.5] - 2020-10-28
 
 - Make `SimpleValue` deserializable within other types (https://github.com/Nadrieril/dhall-rust/issues/184)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ use std::collections::BTreeMap;
 let data = "{ x = 1, y = 1 + 1 } : { x: Natural, y: Natural }";
 
 // Deserialize it to a Rust type.
-let deserialized_map: BTreeMap<String, usize> = serde_dhall::from_str(data).parse().unwrap();
+let deserialized_map: BTreeMap<String, u64> = serde_dhall::from_str(data).parse().unwrap();
 
 let mut expected_map = BTreeMap::new();
 expected_map.insert("x".to_string(), 1);

--- a/dhall/src/builtins.rs
+++ b/dhall/src/builtins.rs
@@ -348,7 +348,7 @@ fn apply_builtin(b: Builtin, args: Vec<Nir>, env: NzEnv) -> NirKind {
             _ => Ret::DoneAsIs,
         },
         (Builtin::NaturalToInteger, [n]) => match &*n.kind() {
-            Num(Natural(n)) => Ret::NirKind(Num(Integer(*n as isize))),
+            Num(Natural(n)) => Ret::NirKind(Num(Integer(*n as i64))),
             _ => Ret::DoneAsIs,
         },
         (Builtin::NaturalShow, [n]) => match &*n.kind() {
@@ -449,7 +449,7 @@ fn apply_builtin(b: Builtin, args: Vec<Nir>, env: NzEnv) -> NirKind {
         }
         (Builtin::ListLength, [_, l]) => match &*l.kind() {
             EmptyListLit(_) => Ret::NirKind(Num(Natural(0))),
-            NEListLit(xs) => Ret::NirKind(Num(Natural(xs.len()))),
+            NEListLit(xs) => Ret::NirKind(Num(Natural(xs.len() as u64))),
             _ => Ret::DoneAsIs,
         },
         (Builtin::ListHead, [_, l]) => match &*l.kind() {
@@ -495,7 +495,7 @@ fn apply_builtin(b: Builtin, args: Vec<Nir>, env: NzEnv) -> NirKind {
                                     let mut kvs = HashMap::new();
                                     kvs.insert(
                                         "index".into(),
-                                        Nir::from_kind(Num(Natural(i))),
+                                        Nir::from_kind(Num(Natural(i as u64))),
                                     );
                                     kvs.insert("value".into(), e.clone());
                                     Nir::from_kind(RecordLit(kvs))

--- a/dhall/src/syntax/ast/expr.rs
+++ b/dhall/src/syntax/ast/expr.rs
@@ -7,9 +7,8 @@ use crate::semantics::Universe;
 use crate::syntax::visitor;
 use crate::syntax::*;
 
-// TODO: `usize` was a mistake. Should use `u64`.
-pub type Integer = isize;
-pub type Natural = usize;
+pub type Integer = i64;
+pub type Natural = u64;
 pub type Double = NaiveDouble;
 
 /// Double with bitwise equality

--- a/dhall/src/syntax/text/parser.rs
+++ b/dhall/src/syntax/text/parser.rs
@@ -378,7 +378,7 @@ impl DhallParser {
         let s = input.as_str().trim();
         if s.starts_with("0x") {
             let without_prefix = s.trim_start_matches("0x");
-            usize::from_str_radix(without_prefix, 16)
+            u64::from_str_radix(without_prefix, 16)
                 .map_err(|e| input.error(format!("{}", e)))
         } else {
             s.parse().map_err(|e| input.error(format!("{}", e)))
@@ -391,7 +391,7 @@ impl DhallParser {
         if rest.starts_with("0x") {
             let without_prefix =
                 sign.to_owned() + rest.trim_start_matches("0x");
-            isize::from_str_radix(&without_prefix, 16)
+            i64::from_str_radix(&without_prefix, 16)
                 .map_err(|e| input.error(format!("{}", e)))
         } else {
             s.parse().map_err(|e| input.error(format!("{}", e)))
@@ -408,7 +408,7 @@ impl DhallParser {
 
     fn variable(input: ParseInput) -> ParseResult<V> {
         Ok(match_nodes!(input.into_children();
-            [label(l), natural_literal(idx)] => V(l, idx),
+            [label(l), natural_literal(idx)] => V(l, idx as usize),
             [label(l)] => V(l, 0),
         ))
     }

--- a/serde_dhall/src/lib.rs
+++ b/serde_dhall/src/lib.rs
@@ -30,7 +30,7 @@
 //! let data = "{ x = 1, y = 1 + 1 } : { x: Natural, y: Natural }";
 //!
 //! // Deserialize it to a Rust type.
-//! let deserialized_map: HashMap<String, usize> = serde_dhall::from_str(data).parse()?;
+//! let deserialized_map: HashMap<String, u64> = serde_dhall::from_str(data).parse()?;
 //!
 //! let mut expected_map = HashMap::new();
 //! expected_map.insert("x".to_string(), 1);
@@ -140,7 +140,7 @@
 //! // the data matches the provided type.
 //! let deserialized_map = serde_dhall::from_str(point_data)
 //!     .type_annotation(&point_type)
-//!     .parse::<HashMap<String, usize>>()?;
+//!     .parse::<HashMap<String, u64>>()?;
 //!
 //! let mut expected_map = HashMap::new();
 //! expected_map.insert("x".to_string(), 1);

--- a/serde_dhall/src/options.rs
+++ b/serde_dhall/src/options.rs
@@ -76,7 +76,7 @@ impl<T: StaticType> HasAnnot<StaticAnnot> for T {
 /// let ty = from_str("{ x: Natural, y: Natural }").parse()?;
 /// let data = from_file("foo.dhall")
 ///             .type_annotation(&ty)
-///             .parse::<HashMap<String, usize>>()?;
+///             .parse::<HashMap<String, u64>>()?;
 /// # Ok(())
 /// # }
 /// ```
@@ -130,7 +130,7 @@ impl<'a> Deserializer<'a, NoAnnot> {
     /// let data = "{ x = 1, y = 1 + 1 }";
     /// let point = from_str(data)
     ///     .type_annotation(&ty)
-    ///     .parse::<HashMap<String, usize>>()?;
+    ///     .parse::<HashMap<String, u64>>()?;
     /// assert_eq!(point.get("y"), Some(&2));
     ///
     /// // Invalid data fails the type validation; deserialization would have succeeded otherwise.
@@ -138,7 +138,7 @@ impl<'a> Deserializer<'a, NoAnnot> {
     /// assert!(
     ///     from_str(invalid_data)
     ///         .type_annotation(&ty)
-    ///         .parse::<HashMap<String, usize>>()
+    ///         .parse::<HashMap<String, u64>>()
     ///         .is_err()
     /// );
     /// # Ok(())

--- a/serde_dhall/tests/de.rs
+++ b/serde_dhall/tests/de.rs
@@ -69,7 +69,7 @@ fn test_de_untyped() {
 
     // Test tuples on record of wrong type
     assert_eq!(
-        parse::<(u64, String, isize)>(r#"{ y = "foo", x = 1, z = +42 }"#),
+        parse::<(u64, String, i64)>(r#"{ y = "foo", x = 1, z = +42 }"#),
         (1, "foo".to_owned(), 42)
     );
 
@@ -77,11 +77,11 @@ fn test_de_untyped() {
     expected_map.insert("x".to_string(), 1);
     expected_map.insert("y".to_string(), 2);
     assert_eq!(
-        parse::<HashMap<String, usize>>("{ x = 1, y = 2 }"),
+        parse::<HashMap<String, u64>>("{ x = 1, y = 2 }"),
         expected_map
     );
     assert_eq!(
-        parse::<HashMap<String, usize>>("toMap { x = 1, y = 2 }"),
+        parse::<HashMap<String, u64>>("toMap { x = 1, y = 2 }"),
         expected_map
     );
 
@@ -90,9 +90,7 @@ fn test_de_untyped() {
     expected_map.insert("FOO_BAR".to_string(), 2);
     expected_map.insert("baz-kux".to_string(), 3);
     assert_eq!(
-        parse::<HashMap<String, usize>>(
-            "{ `if` = 1, FOO_BAR = 2, baz-kux = 3 }"
-        ),
+        parse::<HashMap<String, u64>>("{ `if` = 1, FOO_BAR = 2, baz-kux = 3 }"),
         expected_map
     );
 
@@ -100,7 +98,7 @@ fn test_de_untyped() {
     expected_map.insert("x".to_string(), 1);
     expected_map.insert("y".to_string(), 2);
     assert_eq!(
-        parse::<BTreeMap<String, usize>>("{ x = 1, y = 2 }"),
+        parse::<BTreeMap<String, u64>>("{ x = 1, y = 2 }"),
         expected_map
     );
 


### PR DESCRIPTION
`usize` is for control/indexing numbers; `u64` is for data numbers.