### PR TITLE
Fix a caching-related import bug

### DIFF
--- a/dhall/src/semantics/parse.rs
+++ b/dhall/src/semantics/parse.rs
@@ -2,47 +2,39 @@ use std::path::Path;
 use url::Url;
 
 use crate::error::Error;
-use crate::semantics::resolve::{
-    download_http_text, ImportLocation, ImportLocationKind,
-};
-use crate::syntax::binary;
-use crate::syntax::parse_expr;
+use crate::semantics::resolve::{download_http_text, ImportLocation};
+use crate::syntax::{binary, parse_expr};
 use crate::Parsed;
 
 pub fn parse_file(f: &Path) -> Result<Parsed, Error> {
     let text = std::fs::read_to_string(f)?;
     let expr = parse_expr(&text)?;
-    let root_kind = ImportLocationKind::Local(f.to_owned());
-    let root = ImportLocation { kind: root_kind };
+    let root = ImportLocation::local_dhall_code(f.to_owned());
     Ok(Parsed(expr, root))
 }
 
 pub fn parse_remote(url: Url) -> Result<Parsed, Error> {
     let body = download_http_text(url.clone())?;
     let expr = parse_expr(&body)?;
-    let root_kind = ImportLocationKind::Remote(url);
-    let root = ImportLocation { kind: root_kind };
+    let root = ImportLocation::remote_dhall_code(url);
     Ok(Parsed(expr, root))
 }
 
 pub fn parse_str(s: &str) -> Result<Parsed, Error> {
     let expr = parse_expr(s)?;
-    let root_kind = ImportLocationKind::Missing;
-    let root = ImportLocation { kind: root_kind };
+    let root = ImportLocation::dhall_code_of_unknown_origin();
     Ok(Parsed(expr, root))
 }
 
 pub fn parse_binary(data: &[u8]) -> Result<Parsed, Error> {
     let expr = binary::decode(data)?;
-    let root_kind = ImportLocationKind::Missing;
-    let root = ImportLocation { kind: root_kind };
+    let root = ImportLocation::dhall_code_of_unknown_origin();
     Ok(Parsed(expr, root))
 }
 
 pub fn parse_binary_file(f: &Path) -> Result<Parsed, Error> {
     let data = crate::utils::read_binary_file(f)?;
     let expr = binary::decode(&data)?;
-    let root_kind = ImportLocationKind::Local(f.to_owned());
-    let root = ImportLocation { kind: root_kind };
+    let root = ImportLocation::local_dhall_code(f.to_owned());
     Ok(Parsed(expr, root))
 }

--- a/dhall/src/semantics/parse.rs
+++ b/dhall/src/semantics/parse.rs
@@ -2,7 +2,9 @@ use std::path::Path;
 use url::Url;
 
 use crate::error::Error;
-use crate::semantics::resolve::{download_http_text, ImportLocation};
+use crate::semantics::resolve::{
+    download_http_text, ImportLocation, ImportLocationKind,
+};
 use crate::syntax::binary;
 use crate::syntax::parse_expr;
 use crate::Parsed;
@@ -10,32 +12,37 @@ use crate::Parsed;
 pub fn parse_file(f: &Path) -> Result<Parsed, Error> {
     let text = std::fs::read_to_string(f)?;
     let expr = parse_expr(&text)?;
-    let root = ImportLocation::Local(f.to_owned());
+    let root_kind = ImportLocationKind::Local(f.to_owned());
+    let root = ImportLocation { kind: root_kind };
     Ok(Parsed(expr, root))
 }
 
 pub fn parse_remote(url: Url) -> Result<Parsed, Error> {
     let body = download_http_text(url.clone())?;
     let expr = parse_expr(&body)?;
-    let root = ImportLocation::Remote(url);
+    let root_kind = ImportLocationKind::Remote(url);
+    let root = ImportLocation { kind: root_kind };
     Ok(Parsed(expr, root))
 }
 
 pub fn parse_str(s: &str) -> Result<Parsed, Error> {
     let expr = parse_expr(s)?;
-    let root = ImportLocation::Missing;
+    let root_kind = ImportLocationKind::Missing;
+    let root = ImportLocation { kind: root_kind };
     Ok(Parsed(expr, root))
 }
 
 pub fn parse_binary(data: &[u8]) -> Result<Parsed, Error> {
     let expr = binary::decode(data)?;
-    let root = ImportLocation::Missing;
+    let root_kind = ImportLocationKind::Missing;
+    let root = ImportLocation { kind: root_kind };
     Ok(Parsed(expr, root))
 }
 
 pub fn parse_binary_file(f: &Path) -> Result<Parsed, Error> {
     let data = crate::utils::read_binary_file(f)?;
     let expr = binary::decode(&data)?;
-    let root = ImportLocation::Local(f.to_owned());
+    let root_kind = ImportLocationKind::Local(f.to_owned());
+    let root = ImportLocation { kind: root_kind };
     Ok(Parsed(expr, root))
 }

--- a/dhall/tests/import/failure/cycle.txt
+++ b/dhall/tests/import/failure/cycle.txt
@@ -10,7 +10,7 @@ Type error: error: error
  --> <current file>:1:1
   |
 1 | ../data/cycle.dhall
-  | ^^^^^^^^^^^^^^^^^^^ ImportCycle([ImportLocation { kind: Local("./dhall-lang/tests/import/data/cycle.dhall") }, ImportLocation { kind: Local("./dhall-lang/tests/import/failure/cycle.dhall") }], ImportLocation { kind: Local("./dhall-lang/tests/import/data/cycle.dhall") })
+  | ^^^^^^^^^^^^^^^^^^^ ImportCycle([ImportLocation { kind: Local("./dhall-lang/tests/import/data/cycle.dhall"), mode: Code }, ImportLocation { kind: Local("./dhall-lang/tests/import/failure/cycle.dhall"), mode: Code }], ImportLocation { kind: Local("./dhall-lang/tests/import/data/cycle.dhall"), mode: Code })
   |
   |
   |

--- a/dhall/tests/import/failure/cycle.txt
+++ b/dhall/tests/import/failure/cycle.txt
@@ -10,7 +10,7 @@ Type error: error: error
  --> <current file>:1:1
   |
 1 | ../data/cycle.dhall
-  | ^^^^^^^^^^^^^^^^^^^ ImportCycle([Local("./dhall-lang/tests/import/data/cycle.dhall"), Local("./dhall-lang/tests/import/failure/cycle.dhall")], Local("./dhall-lang/tests/import/data/cycle.dhall"))
+  | ^^^^^^^^^^^^^^^^^^^ ImportCycle([ImportLocation { kind: Local("./dhall-lang/tests/import/data/cycle.dhall") }, ImportLocation { kind: Local("./dhall-lang/tests/import/failure/cycle.dhall") }], ImportLocation { kind: Local("./dhall-lang/tests/import/data/cycle.dhall") })
   |
   |
   |

--- a/dhall/tests/import/success/unit/MixImportModesA.dhall
+++ b/dhall/tests/import/success/unit/MixImportModesA.dhall
@@ -1,0 +1,1 @@
+{ n = ../../data/simple.dhall, txt = ../../data/simple.dhall as Text, loc = ../../data/simple.dhall as Location }

--- a/dhall/tests/import/success/unit/MixImportModesB.dhall
+++ b/dhall/tests/import/success/unit/MixImportModesB.dhall
@@ -1,0 +1,1 @@
+{ loc = < Environment: Text | Local: Text | Missing | Remote: Text >.Local "./dhall/tests/import/data/simple.dhall", n = < Environment: Text | Local: Text | Missing | Remote: Text >.Local "./dhall/tests/import/data/simple.dhall", txt = < Environment: Text | Local: Text | Missing | Remote: Text >.Local "./dhall/tests/import/data/simple.dhall" }

--- a/dhall/tests/import/success/unit/MixImportModesB.dhall
+++ b/dhall/tests/import/success/unit/MixImportModesB.dhall
@@ -1,1 +1,1 @@
-{ loc = < Environment: Text | Local: Text | Missing | Remote: Text >.Local "./dhall/tests/import/data/simple.dhall", n = < Environment: Text | Local: Text | Missing | Remote: Text >.Local "./dhall/tests/import/data/simple.dhall", txt = < Environment: Text | Local: Text | Missing | Remote: Text >.Local "./dhall/tests/import/data/simple.dhall" }
+{ loc = < Environment: Text | Local: Text | Missing | Remote: Text >.Local "./dhall/tests/import/data/simple.dhall", n = 3, txt = "3\n" }

--- a/dhall/tests/spec.rs
+++ b/dhall/tests/spec.rs
@@ -535,8 +535,6 @@ fn ignore_test(variant: SpecTestKind, path: &str) -> bool {
 
     // Failing for now, we should fix that.
     let is_failing_for_now = false
-        // TODO: fix that one
-        // || path == "import/success/unit/MixImportModes"
         // TODO: fails because of caching issues.
         || path == "type-inference/success/prelude"
         // TODO: do not recover from cyclic imports

--- a/dhall/tests/spec.rs
+++ b/dhall/tests/spec.rs
@@ -519,6 +519,7 @@ fn ignore_test(variant: SpecTestKind, path: &str) -> bool {
         // Paths on windows have backslashes; this breaks many things. This is undefined in the
         // spec; see https://github.com/dhall-lang/dhall-lang/issues/1032
         || (variant == ImportSuccess && path.contains("asLocation"))
+        || path == "import/success/unit/MixImportModes"
         || variant == ImportFailure;
 
     // Only include in release tests.

--- a/dhall/tests/spec.rs
+++ b/dhall/tests/spec.rs
@@ -535,6 +535,8 @@ fn ignore_test(variant: SpecTestKind, path: &str) -> bool {
 
     // Failing for now, we should fix that.
     let is_failing_for_now = false
+        // TODO: fix that one
+        // || path == "import/success/unit/MixImportModes"
         // TODO: fails because of caching issues.
         || path == "type-inference/success/prelude"
         // TODO: do not recover from cyclic imports


### PR DESCRIPTION
If we import the same location but normally once and then `as Text`, caching would mix those imports. This fixes that.