### PR TITLE
Refactor import resolution to use a global store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "annotate-snippets",
  "anyhow",
  "colored-diff",
+ "elsa",
  "fs_extra",
  "hex",
  "itertools 0.9.0",
@@ -372,6 +373,15 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "elsa"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0daf12e2857c9485cb2386b18a9ecd5a17c7cee2fd10afb87d436b10ced678e7"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1455,6 +1465,12 @@ dependencies = [
  "redox_syscall",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"

--- a/dhall/Cargo.toml
+++ b/dhall/Cargo.toml
@@ -21,6 +21,7 @@ path = "tests/spec.rs"
 
 [dependencies]
 annotate-snippets = "0.9.0"
+elsa = "1.3.2"
 hex = "0.4.2"
 itertools = "0.9.0"
 lazy_static = "1.4.0"

--- a/dhall/src/builtins.rs
+++ b/dhall/src/builtins.rs
@@ -11,7 +11,6 @@ use crate::syntax::{
     Const, Expr, ExprKind, InterpolatedText, InterpolatedTextContents, Label,
     NaiveDouble, NumKind, Span, UnspannedExpr, V,
 };
-use crate::Ctxt;
 
 /// Built-ins
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -90,25 +89,23 @@ impl Builtin {
 /// A partially applied builtin.
 /// Invariant: the evaluation of the given args must not be able to progress further
 #[derive(Debug, Clone)]
-pub struct BuiltinClosure {
-    env: NzEnv,
+pub struct BuiltinClosure<'cx> {
+    env: NzEnv<'cx>,
     b: Builtin,
     /// Arguments applied to the closure so far.
-    args: Vec<Nir>,
+    args: Vec<Nir<'cx>>,
 }
 
-impl BuiltinClosure {
-    pub fn new(b: Builtin, env: NzEnv) -> NirKind {
-        // TODO: thread cx
-        Ctxt::with_new(|cx| apply_builtin(cx, b, Vec::new(), env))
+impl<'cx> BuiltinClosure<'cx> {
+    pub fn new(b: Builtin, env: NzEnv<'cx>) -> NirKind<'cx> {
+        apply_builtin(b, Vec::new(), env)
     }
-    pub fn apply(&self, a: Nir) -> NirKind {
+    pub fn apply(&self, a: Nir<'cx>) -> NirKind<'cx> {
         use std::iter::once;
         let args = self.args.iter().cloned().chain(once(a)).collect();
-        // TODO: thread cx
-        Ctxt::with_new(|cx| apply_builtin(cx, self.b, args, self.env.clone()))
+        apply_builtin(self.b, args, self.env.clone())
     }
-    pub fn to_hirkind(&self, venv: VarEnv) -> HirKind {
+    pub fn to_hirkind(&self, venv: VarEnv) -> HirKind<'cx> {
         HirKind::Expr(self.args.iter().fold(
             ExprKind::Builtin(self.b),
             |acc, v| {
@@ -181,7 +178,7 @@ macro_rules! make_type {
     };
 }
 
-pub fn type_of_builtin(b: Builtin) -> Hir {
+pub fn type_of_builtin<'cx>(b: Builtin) -> Hir<'cx> {
     use Builtin::*;
     let expr = match b {
         Bool | Natural | Integer | Double | Text => make_type!(Type),
@@ -310,19 +307,19 @@ macro_rules! make_closure {
 }
 
 #[allow(clippy::cognitive_complexity)]
-fn apply_builtin(
-    cx: Ctxt<'_>,
+fn apply_builtin<'cx>(
     b: Builtin,
-    args: Vec<Nir>,
-    env: NzEnv,
-) -> NirKind {
+    args: Vec<Nir<'cx>>,
+    env: NzEnv<'cx>,
+) -> NirKind<'cx> {
+    let cx = env.cx();
     use NirKind::*;
     use NumKind::{Bool, Double, Integer, Natural};
 
     // Small helper enum
-    enum Ret {
-        NirKind(NirKind),
-        Nir(Nir),
+    enum Ret<'cx> {
+        NirKind(NirKind<'cx>),
+        Nir(Nir<'cx>),
         DoneAsIs,
     }
     let make_closure = |e| {
@@ -494,7 +491,7 @@ fn apply_builtin(
                     let mut kts = HashMap::new();
                     kts.insert(
                         "index".into(),
-                        Nir::from_builtin(Builtin::Natural),
+                        Nir::from_builtin(cx, Builtin::Natural),
                     );
                     kts.insert("value".into(), t.clone());
                     let t = Nir::from_kind(RecordType(kts));
@@ -524,7 +521,7 @@ fn apply_builtin(
             }
         }
         (Builtin::ListBuild, [t, f]) => {
-            let list_t = Nir::from_builtin(Builtin::List).app(t.clone());
+            let list_t = Nir::from_builtin(cx, Builtin::List).app(t.clone());
             Ret::Nir(
                 f.app(list_t)
                     .app(
@@ -551,7 +548,7 @@ fn apply_builtin(
             _ => Ret::DoneAsIs,
         },
         (Builtin::NaturalBuild, [f]) => Ret::Nir(
-            f.app(Nir::from_builtin(Builtin::Natural))
+            f.app(Nir::from_builtin(cx, Builtin::Natural))
                 .app(make_closure(make_closure!(
                     λ(x : Natural) ->
                     1 + var(x)
@@ -562,7 +559,7 @@ fn apply_builtin(
         (Builtin::NaturalFold, [n, t, succ, zero]) => match &*n.kind() {
             Num(Natural(0)) => Ret::Nir(zero.clone()),
             Num(Natural(n)) => {
-                let fold = Nir::from_builtin(Builtin::NaturalFold)
+                let fold = Nir::from_builtin(cx, Builtin::NaturalFold)
                     .app(Num(Natural(n - 1)).into_nir())
                     .app(t.clone())
                     .app(succ.clone())
@@ -580,12 +577,12 @@ fn apply_builtin(
     }
 }
 
-impl std::cmp::PartialEq for BuiltinClosure {
+impl<'cx> std::cmp::PartialEq for BuiltinClosure<'cx> {
     fn eq(&self, other: &Self) -> bool {
         self.b == other.b && self.args == other.args
     }
 }
-impl std::cmp::Eq for BuiltinClosure {}
+impl<'cx> std::cmp::Eq for BuiltinClosure<'cx> {}
 
 impl std::fmt::Display for Builtin {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/dhall/src/ctxt.rs
+++ b/dhall/src/ctxt.rs
@@ -83,6 +83,12 @@ impl<'cx> StoredImport<'cx> {
         let res = self.get_resultid()?;
         Some(&self.cx[res])
     }
+    /// Get the result of fetching this import. Panicx if the result has not yet been
+    /// fetched.
+    pub fn unwrap_result(&self) -> &'cx Typed<'cx> {
+        self.get_result()
+            .expect("imports should all have been resolved at this stage")
+    }
     /// Store the result of fetching this import.
     pub fn set_result(&self, res: Typed<'cx>) -> ImportResultId<'cx> {
         let res = self.cx.push_import_result(res);

--- a/dhall/src/ctxt.rs
+++ b/dhall/src/ctxt.rs
@@ -1,0 +1,109 @@
+use elsa::vec::FrozenVec;
+use once_cell::sync::OnceCell;
+
+use crate::semantics::{Import, ImportLocation};
+use crate::syntax::Span;
+use crate::Typed;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ImportId(usize);
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ImportResultId(usize);
+
+struct StoredImport {
+    base_location: ImportLocation,
+    import: Import,
+    span: Span,
+    result: OnceCell<ImportResultId>,
+}
+
+#[derive(Default)]
+struct CtxtS {
+    imports: FrozenVec<Box<StoredImport>>,
+    import_results: FrozenVec<Box<Typed>>,
+}
+
+/// Context for the dhall compiler. Stores various global maps.
+#[derive(Copy, Clone)]
+pub struct Ctxt<'cx>(&'cx CtxtS);
+
+impl Ctxt<'_> {
+    pub fn with_new<T>(f: impl for<'cx> FnOnce(Ctxt<'cx>) -> T) -> T {
+        let cx = CtxtS::default();
+        let cx = Ctxt(&cx);
+        f(cx)
+    }
+}
+impl<'cx> Ctxt<'cx> {
+    fn get_stored_import(self, import: ImportId) -> &'cx StoredImport {
+        self.0.imports.get(import.0).unwrap()
+    }
+    pub fn get_import_result(self, id: ImportResultId) -> &'cx Typed {
+        &self.0.import_results.get(id.0).unwrap()
+    }
+
+    /// Store an import and the location relative to which it must be resolved.
+    pub fn push_import(
+        self,
+        base_location: ImportLocation,
+        import: Import,
+        span: Span,
+    ) -> ImportId {
+        let stored = StoredImport {
+            base_location,
+            import,
+            span,
+            result: OnceCell::new(),
+        };
+        let id = self.0.imports.len();
+        self.0.imports.push(Box::new(stored));
+        ImportId(id)
+    }
+    /// Store the result of fetching an import.
+    pub fn push_import_result(self, res: Typed) -> ImportResultId {
+        let id = self.0.import_results.len();
+        self.0.import_results.push(Box::new(res));
+        ImportResultId(id)
+    }
+
+    pub fn get_import(self, import: ImportId) -> &'cx Import {
+        &self.get_stored_import(import).import
+    }
+    pub fn get_import_base_location(
+        self,
+        import: ImportId,
+    ) -> &'cx ImportLocation {
+        &self.get_stored_import(import).base_location
+    }
+    pub fn get_import_span(self, import: ImportId) -> Span {
+        self.get_stored_import(import).span.clone()
+    }
+    /// Get the result of fetching this import. Returns `None` if the result has not yet been
+    /// fetched.
+    pub fn get_result_of_import(self, import: ImportId) -> Option<&'cx Typed> {
+        let res = self.get_resultid_of_import(import)?;
+        Some(self.get_import_result(res))
+    }
+    /// Get the id of the result of fetching this import. Returns `None` if the result has not yet
+    /// been fetched.
+    pub fn get_resultid_of_import(
+        self,
+        import: ImportId,
+    ) -> Option<ImportResultId> {
+        self.get_stored_import(import).result.get().copied()
+    }
+    /// Store the result of fetching this import.
+    pub fn set_result_of_import(
+        self,
+        import: ImportId,
+        res: Typed,
+    ) -> ImportResultId {
+        let res = self.push_import_result(res);
+        self.set_resultid_of_import(import, res);
+        res
+    }
+    /// Store the result of fetching this import.
+    pub fn set_resultid_of_import(self, import: ImportId, res: ImportResultId) {
+        let _ = self.get_stored_import(import).result.set(res);
+    }
+}

--- a/dhall/src/ctxt.rs
+++ b/dhall/src/ctxt.rs
@@ -1,14 +1,16 @@
 use elsa::vec::FrozenVec;
 use once_cell::sync::OnceCell;
+use std::marker::PhantomData;
+use std::ops::{Deref, Index};
 
 use crate::semantics::{Import, ImportLocation};
 use crate::syntax::Span;
 use crate::Typed;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct ImportId(usize);
+pub struct ImportId<'cx>(usize, PhantomData<&'cx ()>);
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct ImportResultId(usize);
+pub struct ImportResultId<'cx>(usize, PhantomData<&'cx ()>);
 
 /// What's stored for each `ImportId`. Allows getting and setting a result for this import.
 pub struct StoredImport<'cx> {
@@ -16,7 +18,7 @@ pub struct StoredImport<'cx> {
     pub base_location: ImportLocation,
     pub import: Import,
     pub span: Span,
-    result: OnceCell<ImportResultId>,
+    result: OnceCell<ImportResultId<'cx>>,
 }
 
 /// Implementation detail. Made public for the `Index` instances.
@@ -45,7 +47,7 @@ impl<'cx> Ctxt<'cx> {
         base_location: ImportLocation,
         import: Import,
         span: Span,
-    ) -> ImportId {
+    ) -> ImportId<'cx> {
         let stored = StoredImport {
             cx: self,
             base_location,
@@ -55,24 +57,24 @@ impl<'cx> Ctxt<'cx> {
         };
         let id = self.0.imports.len();
         self.0.imports.push(Box::new(stored));
-        ImportId(id)
+        ImportId(id, PhantomData)
     }
     /// Store the result of fetching an import.
-    pub fn push_import_result(self, res: Typed<'cx>) -> ImportResultId {
+    pub fn push_import_result(self, res: Typed<'cx>) -> ImportResultId<'cx> {
         let id = self.0.import_results.len();
         self.0.import_results.push(Box::new(res));
-        ImportResultId(id)
+        ImportResultId(id, PhantomData)
     }
 }
 
 impl<'cx> StoredImport<'cx> {
     /// Get the id of the result of fetching this import. Returns `None` if the result has not yet
     /// been fetched.
-    pub fn get_resultid(&self) -> Option<ImportResultId> {
+    pub fn get_resultid(&self) -> Option<ImportResultId<'cx>> {
         self.result.get().copied()
     }
     /// Store the result of fetching this import.
-    pub fn set_resultid(&self, res: ImportResultId) {
+    pub fn set_resultid(&self, res: ImportResultId<'cx>) {
         let _ = self.result.set(res);
     }
     /// Get the result of fetching this import. Returns `None` if the result has not yet been
@@ -82,30 +84,40 @@ impl<'cx> StoredImport<'cx> {
         Some(&self.cx[res])
     }
     /// Store the result of fetching this import.
-    pub fn set_result(&self, res: Typed<'cx>) -> ImportResultId {
+    pub fn set_result(&self, res: Typed<'cx>) -> ImportResultId<'cx> {
         let res = self.cx.push_import_result(res);
         self.set_resultid(res);
         res
     }
 }
 
-impl<'cx> std::ops::Deref for Ctxt<'cx> {
+impl<'cx> Deref for Ctxt<'cx> {
     type Target = &'cx CtxtS<'cx>;
     fn deref(&self) -> &&'cx CtxtS<'cx> {
         &self.0
     }
 }
 
-impl<'cx> std::ops::Index<ImportId> for CtxtS<'cx> {
+impl<'cx> Index<ImportId<'cx>> for CtxtS<'cx> {
     type Output = StoredImport<'cx>;
-    fn index(&self, id: ImportId) -> &StoredImport<'cx> {
+    fn index(&self, id: ImportId<'cx>) -> &StoredImport<'cx> {
         &self.imports[id.0]
     }
 }
-impl<'cx> std::ops::Index<ImportResultId> for CtxtS<'cx> {
+impl<'cx> Index<ImportResultId<'cx>> for CtxtS<'cx> {
     type Output = Typed<'cx>;
-    fn index(&self, id: ImportResultId) -> &Typed<'cx> {
+    fn index(&self, id: ImportResultId<'cx>) -> &Typed<'cx> {
         &self.import_results[id.0]
+    }
+}
+impl<'a, 'cx, T> Index<&'a T> for CtxtS<'cx>
+where
+    Self: Index<T>,
+    T: Copy,
+{
+    type Output = <Self as Index<T>>::Output;
+    fn index(&self, id: &'a T) -> &Self::Output {
+        &self[*id]
     }
 }
 

--- a/dhall/src/ctxt.rs
+++ b/dhall/src/ctxt.rs
@@ -108,3 +108,11 @@ impl<'cx> std::ops::Index<ImportResultId> for CtxtS<'cx> {
         &self.import_results[id.0]
     }
 }
+
+/// Empty impl, because `FrozenVec` does not implement `Debug` and I can't be bothered to do it
+/// myself.
+impl<'cx> std::fmt::Debug for Ctxt<'cx> {
+    fn fmt(&self, _: &mut std::fmt::Formatter) -> std::fmt::Result {
+        Ok(())
+    }
+}

--- a/dhall/src/ctxt.rs
+++ b/dhall/src/ctxt.rs
@@ -23,7 +23,7 @@ pub struct StoredImport<'cx> {
 #[derive(Default)]
 pub struct CtxtS<'cx> {
     imports: FrozenVec<Box<StoredImport<'cx>>>,
-    import_results: FrozenVec<Box<Typed>>,
+    import_results: FrozenVec<Box<Typed<'cx>>>,
 }
 
 /// Context for the dhall compiler. Stores various global maps.
@@ -58,7 +58,7 @@ impl<'cx> Ctxt<'cx> {
         ImportId(id)
     }
     /// Store the result of fetching an import.
-    pub fn push_import_result(self, res: Typed) -> ImportResultId {
+    pub fn push_import_result(self, res: Typed<'cx>) -> ImportResultId {
         let id = self.0.import_results.len();
         self.0.import_results.push(Box::new(res));
         ImportResultId(id)
@@ -77,12 +77,12 @@ impl<'cx> StoredImport<'cx> {
     }
     /// Get the result of fetching this import. Returns `None` if the result has not yet been
     /// fetched.
-    pub fn get_result(&self) -> Option<&'cx Typed> {
+    pub fn get_result(&self) -> Option<&'cx Typed<'cx>> {
         let res = self.get_resultid()?;
         Some(&self.cx[res])
     }
     /// Store the result of fetching this import.
-    pub fn set_result(&self, res: Typed) -> ImportResultId {
+    pub fn set_result(&self, res: Typed<'cx>) -> ImportResultId {
         let res = self.cx.push_import_result(res);
         self.set_resultid(res);
         res
@@ -103,8 +103,8 @@ impl<'cx> std::ops::Index<ImportId> for CtxtS<'cx> {
     }
 }
 impl<'cx> std::ops::Index<ImportResultId> for CtxtS<'cx> {
-    type Output = Typed;
-    fn index(&self, id: ImportResultId) -> &Typed {
+    type Output = Typed<'cx>;
+    fn index(&self, id: ImportResultId) -> &Typed<'cx> {
         &self.import_results[id.0]
     }
 }

--- a/dhall/src/ctxt.rs
+++ b/dhall/src/ctxt.rs
@@ -3,29 +3,19 @@ use once_cell::sync::OnceCell;
 use std::marker::PhantomData;
 use std::ops::{Deref, Index};
 
-use crate::semantics::{Import, ImportLocation};
+use crate::semantics::{Import, ImportLocation, ImportNode};
 use crate::syntax::Span;
 use crate::Typed;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct ImportId<'cx>(usize, PhantomData<&'cx ()>);
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct ImportResultId<'cx>(usize, PhantomData<&'cx ()>);
-
-/// What's stored for each `ImportId`. Allows getting and setting a result for this import.
-pub struct StoredImport<'cx> {
-    cx: Ctxt<'cx>,
-    pub base_location: ImportLocation,
-    pub import: Import,
-    pub span: Span,
-    result: OnceCell<ImportResultId<'cx>>,
-}
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+// Ctxt
 
 /// Implementation detail. Made public for the `Index` instances.
 #[derive(Default)]
 pub struct CtxtS<'cx> {
     imports: FrozenVec<Box<StoredImport<'cx>>>,
-    import_results: FrozenVec<Box<Typed<'cx>>>,
+    import_alternatives: FrozenVec<Box<StoredImportAlternative<'cx>>>,
+    import_results: FrozenVec<Box<StoredImportResult<'cx>>>,
 }
 
 /// Context for the dhall compiler. Stores various global maps.
@@ -38,6 +28,78 @@ impl Ctxt<'_> {
         let cx = CtxtS::default();
         let cx = Ctxt(&cx);
         f(cx)
+    }
+}
+impl<'cx> Deref for Ctxt<'cx> {
+    type Target = &'cx CtxtS<'cx>;
+    fn deref(&self) -> &&'cx CtxtS<'cx> {
+        &self.0
+    }
+}
+impl<'a, 'cx, T> Index<&'a T> for CtxtS<'cx>
+where
+    Self: Index<T>,
+    T: Copy,
+{
+    type Output = <Self as Index<T>>::Output;
+    fn index(&self, id: &'a T) -> &Self::Output {
+        &self[*id]
+    }
+}
+
+/// Empty impl, because `FrozenVec` does not implement `Debug` and I can't be bothered to do it
+/// myself.
+impl<'cx> std::fmt::Debug for Ctxt<'cx> {
+    fn fmt(&self, _: &mut std::fmt::Formatter) -> std::fmt::Result {
+        Ok(())
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+// Imports
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ImportId<'cx>(usize, PhantomData<&'cx ()>);
+
+/// What's stored for each `ImportId`. Allows getting and setting a result for this import.
+pub struct StoredImport<'cx> {
+    cx: Ctxt<'cx>,
+    pub base_location: ImportLocation,
+    pub import: Import,
+    pub span: Span,
+    result: OnceCell<ImportResultId<'cx>>,
+}
+
+impl<'cx> StoredImport<'cx> {
+    /// Get the id of the result of fetching this import. Returns `None` if the result has not yet
+    /// been fetched.
+    pub fn get_resultid(&self) -> Option<ImportResultId<'cx>> {
+        self.result.get().copied()
+    }
+    /// Store the result of fetching this import.
+    pub fn set_resultid(&self, res: ImportResultId<'cx>) {
+        let _ = self.result.set(res);
+    }
+    /// Get the result of fetching this import. Returns `None` if the result has not yet been
+    /// fetched.
+    pub fn get_result(&self) -> Option<&'cx StoredImportResult<'cx>> {
+        let res = self.get_resultid()?;
+        Some(&self.cx[res])
+    }
+    /// Get the result of fetching this import. Panicx if the result has not yet been
+    /// fetched.
+    pub fn unwrap_result(&self) -> &'cx StoredImportResult<'cx> {
+        self.get_result()
+            .expect("imports should all have been resolved at this stage")
+    }
+    /// Store the result of fetching this import.
+    pub fn set_result(
+        &self,
+        res: StoredImportResult<'cx>,
+    ) -> ImportResultId<'cx> {
+        let res = self.cx.push_import_result(res);
+        self.set_resultid(res);
+        res
     }
 }
 impl<'cx> Ctxt<'cx> {
@@ -59,78 +121,91 @@ impl<'cx> Ctxt<'cx> {
         self.0.imports.push(Box::new(stored));
         ImportId(id, PhantomData)
     }
-    /// Store the result of fetching an import.
-    pub fn push_import_result(self, res: Typed<'cx>) -> ImportResultId<'cx> {
-        let id = self.0.import_results.len();
-        self.0.import_results.push(Box::new(res));
-        ImportResultId(id, PhantomData)
-    }
 }
-
-impl<'cx> StoredImport<'cx> {
-    /// Get the id of the result of fetching this import. Returns `None` if the result has not yet
-    /// been fetched.
-    pub fn get_resultid(&self) -> Option<ImportResultId<'cx>> {
-        self.result.get().copied()
-    }
-    /// Store the result of fetching this import.
-    pub fn set_resultid(&self, res: ImportResultId<'cx>) {
-        let _ = self.result.set(res);
-    }
-    /// Get the result of fetching this import. Returns `None` if the result has not yet been
-    /// fetched.
-    pub fn get_result(&self) -> Option<&'cx Typed<'cx>> {
-        let res = self.get_resultid()?;
-        Some(&self.cx[res])
-    }
-    /// Get the result of fetching this import. Panicx if the result has not yet been
-    /// fetched.
-    pub fn unwrap_result(&self) -> &'cx Typed<'cx> {
-        self.get_result()
-            .expect("imports should all have been resolved at this stage")
-    }
-    /// Store the result of fetching this import.
-    pub fn set_result(&self, res: Typed<'cx>) -> ImportResultId<'cx> {
-        let res = self.cx.push_import_result(res);
-        self.set_resultid(res);
-        res
-    }
-}
-
-impl<'cx> Deref for Ctxt<'cx> {
-    type Target = &'cx CtxtS<'cx>;
-    fn deref(&self) -> &&'cx CtxtS<'cx> {
-        &self.0
-    }
-}
-
 impl<'cx> Index<ImportId<'cx>> for CtxtS<'cx> {
     type Output = StoredImport<'cx>;
     fn index(&self, id: ImportId<'cx>) -> &StoredImport<'cx> {
         &self.imports[id.0]
     }
 }
-impl<'cx> Index<ImportResultId<'cx>> for CtxtS<'cx> {
-    type Output = Typed<'cx>;
-    fn index(&self, id: ImportResultId<'cx>) -> &Typed<'cx> {
-        &self.import_results[id.0]
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+// Import alternatives
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ImportAlternativeId<'cx>(usize, PhantomData<&'cx ()>);
+
+/// What's stored for each `ImportAlternativeId`.
+pub struct StoredImportAlternative<'cx> {
+    pub left_imports: Box<[ImportNode<'cx>]>,
+    pub right_imports: Box<[ImportNode<'cx>]>,
+    /// `true` for left, `false` for right.
+    selected: OnceCell<bool>,
+}
+
+impl<'cx> StoredImportAlternative<'cx> {
+    /// Get which alternative got selected. `true` for left, `false` for right.
+    pub fn get_selected(&self) -> Option<bool> {
+        self.selected.get().copied()
+    }
+    /// Get which alternative got selected. `true` for left, `false` for right.
+    pub fn unwrap_selected(&self) -> bool {
+        self.get_selected()
+            .expect("imports should all have been resolved at this stage")
+    }
+    /// Set which alternative got selected. `true` for left, `false` for right.
+    pub fn set_selected(&self, selected: bool) {
+        let _ = self.selected.set(selected);
     }
 }
-impl<'a, 'cx, T> Index<&'a T> for CtxtS<'cx>
-where
-    Self: Index<T>,
-    T: Copy,
-{
-    type Output = <Self as Index<T>>::Output;
-    fn index(&self, id: &'a T) -> &Self::Output {
-        &self[*id]
+impl<'cx> Ctxt<'cx> {
+    pub fn push_import_alternative(
+        self,
+        left_imports: Box<[ImportNode<'cx>]>,
+        right_imports: Box<[ImportNode<'cx>]>,
+    ) -> ImportAlternativeId<'cx> {
+        let stored = StoredImportAlternative {
+            left_imports,
+            right_imports,
+            selected: OnceCell::new(),
+        };
+        let id = self.0.import_alternatives.len();
+        self.0.import_alternatives.push(Box::new(stored));
+        ImportAlternativeId(id, PhantomData)
+    }
+}
+impl<'cx> Index<ImportAlternativeId<'cx>> for CtxtS<'cx> {
+    type Output = StoredImportAlternative<'cx>;
+    fn index(
+        &self,
+        id: ImportAlternativeId<'cx>,
+    ) -> &StoredImportAlternative<'cx> {
+        &self.import_alternatives[id.0]
     }
 }
 
-/// Empty impl, because `FrozenVec` does not implement `Debug` and I can't be bothered to do it
-/// myself.
-impl<'cx> std::fmt::Debug for Ctxt<'cx> {
-    fn fmt(&self, _: &mut std::fmt::Formatter) -> std::fmt::Result {
-        Ok(())
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+// Import results
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ImportResultId<'cx>(usize, PhantomData<&'cx ()>);
+
+type StoredImportResult<'cx> = Typed<'cx>;
+
+impl<'cx> Ctxt<'cx> {
+    /// Store the result of fetching an import.
+    pub fn push_import_result(
+        self,
+        res: StoredImportResult<'cx>,
+    ) -> ImportResultId<'cx> {
+        let id = self.0.import_results.len();
+        self.0.import_results.push(Box::new(res));
+        ImportResultId(id, PhantomData)
+    }
+}
+impl<'cx> Index<ImportResultId<'cx>> for CtxtS<'cx> {
+    type Output = StoredImportResult<'cx>;
+    fn index(&self, id: ImportResultId<'cx>) -> &StoredImportResult<'cx> {
+        &self.import_results[id.0]
     }
 }

--- a/dhall/src/lib.rs
+++ b/dhall/src/lib.rs
@@ -5,8 +5,7 @@
     clippy::needless_lifetimes,
     clippy::new_ret_no_self,
     clippy::new_without_default,
-    clippy::useless_format,
-    unreachable_code
+    clippy::useless_format
 )]
 
 pub mod builtins;
@@ -17,7 +16,6 @@ pub mod semantics;
 pub mod syntax;
 pub mod utils;
 
-use std::fmt::Display;
 use std::path::Path;
 use url::Url;
 
@@ -102,8 +100,8 @@ impl<'cx> Resolved<'cx> {
         Ok(Typed::from_tir(typecheck_with(cx, &self.0, ty)?))
     }
     /// Converts a value back to the corresponding AST expression.
-    pub fn to_expr(&self) -> Expr {
-        self.0.to_expr_noopts()
+    pub fn to_expr(&self, cx: Ctxt<'cx>) -> Expr {
+        self.0.to_expr_noopts(cx)
     }
 }
 
@@ -120,8 +118,8 @@ impl<'cx> Typed<'cx> {
     }
 
     /// Converts a value back to the corresponding AST expression.
-    fn to_expr(&self) -> Expr {
-        self.hir.to_expr(ToExprOptions { alpha: false })
+    fn to_expr(&self, cx: Ctxt<'cx>) -> Expr {
+        self.hir.to_expr(cx, ToExprOptions { alpha: false })
     }
 
     pub fn ty(&self) -> &Type<'cx> {
@@ -134,8 +132,8 @@ impl<'cx> Typed<'cx> {
 
 impl<'cx> Normalized<'cx> {
     /// Converts a value back to the corresponding AST expression.
-    pub fn to_expr(&self) -> Expr {
-        self.0.to_expr(ToExprOptions::default())
+    pub fn to_expr(&self, cx: Ctxt<'cx>) -> Expr {
+        self.0.to_expr(cx, ToExprOptions::default())
     }
     /// Converts a value back to the corresponding Hir expression.
     pub fn to_hir(&self) -> Hir<'cx> {
@@ -145,8 +143,8 @@ impl<'cx> Normalized<'cx> {
         &self.0
     }
     /// Converts a value back to the corresponding AST expression, alpha-normalizing in the process.
-    pub fn to_expr_alpha(&self) -> Expr {
-        self.0.to_expr(ToExprOptions { alpha: true })
+    pub fn to_expr_alpha(&self, cx: Ctxt<'cx>) -> Expr {
+        self.0.to_expr(cx, ToExprOptions { alpha: true })
     }
 }
 
@@ -178,32 +176,10 @@ impl From<Parsed> for Expr {
         other.to_expr()
     }
 }
-impl<'cx> From<Normalized<'cx>> for Expr {
-    fn from(other: Normalized<'cx>) -> Self {
-        other.to_expr()
-    }
-}
-
-impl<'cx> Display for Resolved<'cx> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        self.to_expr().fmt(f)
-    }
-}
-
-impl<'cx> Display for Typed<'cx> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        self.to_expr().fmt(f)
-    }
-}
 
 impl<'cx> Eq for Normalized<'cx> {}
 impl<'cx> PartialEq for Normalized<'cx> {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
-    }
-}
-impl<'cx> Display for Normalized<'cx> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        self.to_expr().fmt(f)
     }
 }

--- a/dhall/src/lib.rs
+++ b/dhall/src/lib.rs
@@ -77,7 +77,8 @@ impl Parsed {
     }
 
     pub fn resolve(self) -> Result<Resolved, Error> {
-        resolve::resolve(self)
+        // TODO: thread cx
+        Ctxt::with_new(|cx| resolve::resolve(cx, self))
     }
     pub fn skip_resolve(self) -> Result<Resolved, Error> {
         resolve::skip_resolve(self)
@@ -91,10 +92,14 @@ impl Parsed {
 
 impl Resolved {
     pub fn typecheck(&self) -> Result<Typed, TypeError> {
-        Ok(Typed::from_tir(typecheck(&self.0)?))
+        // TODO: thread cx
+        Ctxt::with_new(|cx| Ok(Typed::from_tir(typecheck(cx, &self.0)?)))
     }
     pub fn typecheck_with(self, ty: &Hir) -> Result<Typed, TypeError> {
-        Ok(Typed::from_tir(typecheck_with(&self.0, ty)?))
+        // TODO: thread cx
+        Ctxt::with_new(|cx| {
+            Ok(Typed::from_tir(typecheck_with(cx, &self.0, ty)?))
+        })
     }
     /// Converts a value back to the corresponding AST expression.
     pub fn to_expr(&self) -> Expr {

--- a/dhall/src/lib.rs
+++ b/dhall/src/lib.rs
@@ -58,6 +58,11 @@ pub struct ToExprOptions {
 }
 
 impl Parsed {
+    /// Construct from an `Expr`. This `Expr` will have imports disabled.
+    pub fn from_expr_without_imports(e: Expr) -> Self {
+        Parsed(e, ImportLocation::dhall_code_without_imports())
+    }
+
     pub fn parse_file(f: &Path) -> Result<Parsed, Error> {
         parse::parse_file(f)
     }
@@ -78,8 +83,11 @@ impl Parsed {
     pub fn resolve<'cx>(self, cx: Ctxt<'cx>) -> Result<Resolved<'cx>, Error> {
         resolve::resolve(cx, self)
     }
-    pub fn skip_resolve<'cx>(self) -> Result<Resolved<'cx>, Error> {
-        resolve::skip_resolve(self)
+    pub fn skip_resolve<'cx>(
+        self,
+        cx: Ctxt<'cx>,
+    ) -> Result<Resolved<'cx>, Error> {
+        resolve::skip_resolve(cx, self)
     }
 
     /// Converts a value back to the corresponding AST expression.
@@ -122,6 +130,9 @@ impl<'cx> Typed<'cx> {
         self.hir.to_expr(cx, ToExprOptions { alpha: false })
     }
 
+    pub fn as_hir(&self) -> &Hir<'cx> {
+        &self.hir
+    }
     pub fn ty(&self) -> &Type<'cx> {
         &self.ty
     }

--- a/dhall/src/lib.rs
+++ b/dhall/src/lib.rs
@@ -9,6 +9,7 @@
 )]
 
 pub mod builtins;
+pub mod ctxt;
 pub mod error;
 pub mod operations;
 pub mod semantics;
@@ -25,6 +26,8 @@ use crate::semantics::resolve;
 use crate::semantics::resolve::ImportLocation;
 use crate::semantics::{typecheck, typecheck_with, Hir, Nir, Tir, Type};
 use crate::syntax::Expr;
+
+pub use ctxt::{Ctxt, ImportId, ImportResultId};
 
 #[derive(Debug, Clone)]
 pub struct Parsed(Expr, ImportLocation);

--- a/dhall/src/lib.rs
+++ b/dhall/src/lib.rs
@@ -5,6 +5,7 @@
     clippy::needless_lifetimes,
     clippy::new_ret_no_self,
     clippy::new_without_default,
+    clippy::try_err,
     clippy::useless_format
 )]
 

--- a/dhall/src/lib.rs
+++ b/dhall/src/lib.rs
@@ -26,7 +26,7 @@ use crate::semantics::resolve::ImportLocation;
 use crate::semantics::{typecheck, typecheck_with, Hir, Nir, Tir, Type};
 use crate::syntax::Expr;
 
-pub use ctxt::{Ctxt, ImportId, ImportResultId};
+pub use ctxt::*;
 
 #[derive(Debug, Clone)]
 pub struct Parsed(Expr, ImportLocation);

--- a/dhall/src/operations/normalization.rs
+++ b/dhall/src/operations/normalization.rs
@@ -8,7 +8,7 @@ use crate::semantics::{
 };
 use crate::syntax::{ExprKind, Label, NumKind};
 
-fn normalize_binop(o: BinOp, x: Nir, y: Nir) -> Ret {
+fn normalize_binop<'cx>(o: BinOp, x: Nir<'cx>, y: Nir<'cx>) -> Ret<'cx> {
     use BinOp::*;
     use NirKind::{EmptyListLit, NEListLit, Num, RecordLit, RecordType};
     use NumKind::{Bool, Natural};
@@ -119,7 +119,7 @@ fn normalize_binop(o: BinOp, x: Nir, y: Nir) -> Ret {
     }
 }
 
-fn normalize_field(v: &Nir, field: &Label) -> Ret {
+fn normalize_field<'cx>(v: &Nir<'cx>, field: &Label) -> Ret<'cx> {
     use self::BinOp::{RecursiveRecordMerge, RightBiasedRecordMerge};
     use NirKind::{Op, RecordLit, UnionConstructor, UnionType};
     use OpKind::{BinOp, Field, Projection};
@@ -187,7 +187,7 @@ fn normalize_field(v: &Nir, field: &Label) -> Ret {
     }
 }
 
-pub fn normalize_operation(opkind: OpKind<Nir>) -> Ret {
+pub fn normalize_operation<'cx>(opkind: OpKind<Nir<'cx>>) -> Ret<'cx> {
     use self::BinOp::RightBiasedRecordMerge;
     use NirKind::{
         EmptyListLit, EmptyOptionalLit, NEListLit, NEOptionalLit, Num, Op,

--- a/dhall/src/operations/typecheck.rs
+++ b/dhall/src/operations/typecheck.rs
@@ -13,7 +13,7 @@ use crate::syntax::{Const, ExprKind, Span};
 
 fn check_rectymerge(
     span: &Span,
-    env: &TyEnv,
+    env: &TyEnv<'_>,
     x: Nir,
     y: Nir,
 ) -> Result<(), TypeError> {
@@ -45,7 +45,7 @@ fn check_rectymerge(
 }
 
 fn typecheck_binop(
-    env: &TyEnv,
+    env: &TyEnv<'_>,
     span: Span,
     op: BinOp,
     l: Tir<'_>,
@@ -150,7 +150,7 @@ fn typecheck_binop(
 }
 
 fn typecheck_merge(
-    env: &TyEnv,
+    env: &TyEnv<'_>,
     span: Span,
     record: &Tir<'_>,
     scrut: &Tir<'_>,
@@ -288,7 +288,7 @@ fn typecheck_merge(
 }
 
 pub fn typecheck_operation(
-    env: &TyEnv,
+    env: &TyEnv<'_>,
     span: Span,
     opkind: OpKind<Tir<'_>>,
 ) -> Result<Type, TypeError> {

--- a/dhall/src/semantics/nze/nir.rs
+++ b/dhall/src/semantics/nze/nir.rs
@@ -148,8 +148,8 @@ impl<'cx> Nir<'cx> {
         Type::new(self.clone(), u.into())
     }
     /// Converts a value back to the corresponding AST expression.
-    pub fn to_expr(&self, opts: ToExprOptions) -> Expr {
-        self.to_hir_noenv().to_expr(opts)
+    pub fn to_expr(&self, cx: Ctxt<'cx>, opts: ToExprOptions) -> Expr {
+        self.to_hir_noenv().to_expr(cx, opts)
     }
     pub fn to_expr_tyenv(&self, tyenv: &TyEnv<'cx>) -> Expr {
         self.to_hir(tyenv.as_varenv()).to_expr_tyenv(tyenv)

--- a/dhall/src/semantics/nze/nir.rs
+++ b/dhall/src/semantics/nze/nir.rs
@@ -11,7 +11,7 @@ use crate::semantics::{
 use crate::syntax::{
     Const, Expr, ExprKind, InterpolatedTextContents, Label, NumKind, Span,
 };
-use crate::ToExprOptions;
+use crate::{Ctxt, ToExprOptions};
 
 /// Stores a possibly unevaluated value. Gets (partially) normalized on-demand, sharing computation
 /// automatically. Uses a Rc<OnceCell> to share computation.
@@ -20,31 +20,31 @@ use crate::ToExprOptions;
 /// normalize as needed.
 /// Stands for "Normalized Intermediate Representation"
 #[derive(Clone)]
-pub struct Nir(Rc<lazy::Lazy<Thunk, NirKind>>);
+pub struct Nir<'cx>(Rc<lazy::Lazy<Thunk<'cx>, NirKind<'cx>>>);
 
 /// An unevaluated subexpression
 #[derive(Debug, Clone)]
-pub enum Thunk {
+pub enum Thunk<'cx> {
     /// A completely unnormalized expression.
-    Thunk { env: NzEnv, body: Hir },
+    Thunk { env: NzEnv<'cx>, body: Hir<'cx> },
     /// A partially normalized expression that may need to go through `normalize_one_layer`.
-    PartialExpr { env: NzEnv, expr: ExprKind<Nir> },
+    PartialExpr { expr: ExprKind<Nir<'cx>> },
 }
 
 /// An unevaluated subexpression that takes an argument.
 #[derive(Debug, Clone)]
-pub enum Closure {
+pub enum Closure<'cx> {
     /// Normal closure
-    Closure { env: NzEnv, body: Hir },
+    Closure { env: NzEnv<'cx>, body: Hir<'cx> },
     /// Closure that ignores the argument passed
-    ConstantClosure { body: Nir },
+    ConstantClosure { body: Nir<'cx> },
 }
 
 /// A text literal with interpolations.
 // Invariant: this must not contain interpolations that are themselves TextLits, and contiguous
 // text values must be merged.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TextLit(Vec<InterpolatedTextContents<Nir>>);
+pub struct TextLit<'cx>(Vec<InterpolatedTextContents<Nir<'cx>>>);
 
 /// This represents a value in Weak Head Normal Form (WHNF). This means that the value is
 /// normalized up to the first constructor, but subexpressions may not be fully normalized.
@@ -54,67 +54,65 @@ pub struct TextLit(Vec<InterpolatedTextContents<Nir>>);
 /// In particular, this means that once we get a `NirKind`, it can be considered immutable, and
 /// we only need to recursively normalize its sub-`Nir`s to get to the NF.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NirKind {
+pub enum NirKind<'cx> {
     /// Closures
     LamClosure {
         binder: Binder,
-        annot: Nir,
-        closure: Closure,
+        annot: Nir<'cx>,
+        closure: Closure<'cx>,
     },
     PiClosure {
         binder: Binder,
-        annot: Nir,
-        closure: Closure,
+        annot: Nir<'cx>,
+        closure: Closure<'cx>,
     },
-    AppliedBuiltin(BuiltinClosure),
+    AppliedBuiltin(BuiltinClosure<'cx>),
 
     Var(NzVar),
     Const(Const),
     Num(NumKind),
     // Must be a number type, Bool or Text
     BuiltinType(Builtin),
-    TextLit(TextLit),
-    EmptyOptionalLit(Nir),
-    NEOptionalLit(Nir),
-    OptionalType(Nir),
+    TextLit(TextLit<'cx>),
+    EmptyOptionalLit(Nir<'cx>),
+    NEOptionalLit(Nir<'cx>),
+    OptionalType(Nir<'cx>),
     // EmptyListLit(t) means `[] : List t`, not `[] : t`
-    EmptyListLit(Nir),
-    NEListLit(Vec<Nir>),
-    ListType(Nir),
-    RecordLit(HashMap<Label, Nir>),
-    RecordType(HashMap<Label, Nir>),
-    UnionConstructor(Label, HashMap<Label, Option<Nir>>),
-    UnionLit(Label, Nir, HashMap<Label, Option<Nir>>),
-    UnionType(HashMap<Label, Option<Nir>>),
-    Equivalence(Nir, Nir),
-    Assert(Nir),
+    EmptyListLit(Nir<'cx>),
+    NEListLit(Vec<Nir<'cx>>),
+    ListType(Nir<'cx>),
+    RecordLit(HashMap<Label, Nir<'cx>>),
+    RecordType(HashMap<Label, Nir<'cx>>),
+    UnionConstructor(Label, HashMap<Label, Option<Nir<'cx>>>),
+    UnionLit(Label, Nir<'cx>, HashMap<Label, Option<Nir<'cx>>>),
+    UnionType(HashMap<Label, Option<Nir<'cx>>>),
+    Equivalence(Nir<'cx>, Nir<'cx>),
+    Assert(Nir<'cx>),
     /// Invariant: evaluation must not be able to progress with `normalize_operation`.
     /// This is used when an operation couldn't proceed further, for example because of variables.
-    Op(OpKind<Nir>),
+    Op(OpKind<Nir<'cx>>),
 }
 
-impl Nir {
+impl<'cx> Nir<'cx> {
     /// Construct a Nir from a completely unnormalized expression.
-    pub fn new_thunk(env: NzEnv, hir: Hir) -> Nir {
+    pub fn new_thunk(env: NzEnv<'cx>, hir: Hir<'cx>) -> Self {
         Nir(Rc::new(lazy::Lazy::new(Thunk::new(env, hir))))
     }
     /// Construct a Nir from a partially normalized expression that's not in WHNF.
-    pub fn from_partial_expr(e: ExprKind<Nir>) -> Nir {
-        // TODO: env
-        let env = NzEnv::new();
-        Nir(Rc::new(lazy::Lazy::new(Thunk::from_partial_expr(env, e))))
+    pub fn from_partial_expr(e: ExprKind<Self>) -> Self {
+        Nir(Rc::new(lazy::Lazy::new(Thunk::from_partial_expr(e))))
     }
     /// Make a Nir from a NirKind
-    pub fn from_kind(v: NirKind) -> Nir {
+    pub fn from_kind(v: NirKind<'cx>) -> Self {
         Nir(Rc::new(lazy::Lazy::new_completed(v)))
     }
     pub fn from_const(c: Const) -> Self {
         Self::from_kind(NirKind::Const(c))
     }
-    pub fn from_builtin(b: Builtin) -> Self {
-        Self::from_builtin_env(b, &NzEnv::new())
+    pub fn from_builtin(cx: Ctxt<'cx>, b: Builtin) -> Self {
+        Self::from_builtin_env(b, &NzEnv::new(cx))
     }
-    pub fn from_builtin_env(b: Builtin, env: &NzEnv) -> Self {
+    pub fn from_builtin_env(b: Builtin, env: &NzEnv<'cx>) -> Self {
         Nir::from_kind(NirKind::from_builtin_env(b, env.clone()))
     }
     pub fn from_text(txt: impl ToString) -> Self {
@@ -129,51 +127,54 @@ impl Nir {
     }
 
     /// This is what you want if you want to pattern-match on the value.
-    pub fn kind(&self) -> &NirKind {
+    pub fn kind(&self) -> &NirKind<'cx> {
         &*self.0
     }
 
     /// The contents of a `Nir` are immutable and shared. If however we happen to be the sole
     /// owners, we can mutate it directly. Otherwise, this clones the internal value first.
-    pub fn kind_mut(&mut self) -> &mut NirKind {
+    pub fn kind_mut(&mut self) -> &mut NirKind<'cx> {
         Rc::make_mut(&mut self.0).get_mut()
     }
     /// If we are the sole owner of this Nir, we can avoid a clone.
-    pub fn into_kind(self) -> NirKind {
+    pub fn into_kind(self) -> NirKind<'cx> {
         match Rc::try_unwrap(self.0) {
             Ok(lazy) => lazy.into_inner(),
             Err(rc) => (**rc).clone(),
         }
     }
 
-    pub fn to_type(&self, u: impl Into<Universe>) -> Type {
+    pub fn to_type(&self, u: impl Into<Universe>) -> Type<'cx> {
         Type::new(self.clone(), u.into())
     }
     /// Converts a value back to the corresponding AST expression.
     pub fn to_expr(&self, opts: ToExprOptions) -> Expr {
         self.to_hir_noenv().to_expr(opts)
     }
-    pub fn to_expr_tyenv(&self, tyenv: &TyEnv) -> Expr {
+    pub fn to_expr_tyenv(&self, tyenv: &TyEnv<'cx>) -> Expr {
         self.to_hir(tyenv.as_varenv()).to_expr_tyenv(tyenv)
     }
 
-    pub fn app(&self, v: Nir) -> Nir {
+    pub fn app(&self, v: Self) -> Self {
         Nir::from_kind(self.app_to_kind(v))
     }
-    pub fn app_to_kind(&self, v: Nir) -> NirKind {
+    pub fn app_to_kind(&self, v: Self) -> NirKind<'cx> {
         apply_any(self, v)
     }
 
-    pub fn to_hir(&self, venv: VarEnv) -> Hir {
-        let map_uniontype = |kts: &HashMap<Label, Option<Nir>>| {
-            ExprKind::UnionType(
-                kts.iter()
-                    .map(|(k, v)| {
-                        (k.clone(), v.as_ref().map(|v| v.to_hir(venv)))
-                    })
-                    .collect(),
-            )
-        };
+    pub fn to_hir(&self, venv: VarEnv) -> Hir<'cx> {
+        let map_uniontype =
+            |kts: &HashMap<Label, Option<Nir<'cx>>>| -> ExprKind<Hir<'cx>> {
+                ExprKind::UnionType(
+                    kts.iter()
+                        .map(|(k, v)| {
+                            (k.clone(), v.as_ref().map(|v| v.to_hir(venv)))
+                        })
+                        .collect(),
+                )
+            };
+        let builtin =
+            |b| Hir::new(HirKind::Expr(ExprKind::Builtin(b)), Span::Artificial);
 
         let hir = match self.kind() {
             NirKind::Var(v) => HirKind::Var(venv.lookup(*v)),
@@ -204,21 +205,21 @@ impl Nir {
                 NirKind::BuiltinType(b) => ExprKind::Builtin(*b),
                 NirKind::Num(l) => ExprKind::Num(l.clone()),
                 NirKind::OptionalType(t) => ExprKind::Op(OpKind::App(
-                    Nir::from_builtin(Builtin::Optional).to_hir(venv),
+                    builtin(Builtin::Optional),
                     t.to_hir(venv),
                 )),
                 NirKind::EmptyOptionalLit(n) => ExprKind::Op(OpKind::App(
-                    Nir::from_builtin(Builtin::OptionalNone).to_hir(venv),
+                    builtin(Builtin::OptionalNone),
                     n.to_hir(venv),
                 )),
                 NirKind::NEOptionalLit(n) => ExprKind::SomeLit(n.to_hir(venv)),
                 NirKind::ListType(t) => ExprKind::Op(OpKind::App(
-                    Nir::from_builtin(Builtin::List).to_hir(venv),
+                    builtin(Builtin::List),
                     t.to_hir(venv),
                 )),
                 NirKind::EmptyListLit(n) => ExprKind::EmptyListLit(Hir::new(
                     HirKind::Expr(ExprKind::Op(OpKind::App(
-                        Nir::from_builtin(Builtin::List).to_hir(venv),
+                        builtin(Builtin::List),
                         n.to_hir(venv),
                     ))),
                     Span::Artificial,
@@ -276,52 +277,52 @@ impl Nir {
 
         Hir::new(hir, Span::Artificial)
     }
-    pub fn to_hir_noenv(&self) -> Hir {
+    pub fn to_hir_noenv(&self) -> Hir<'cx> {
         self.to_hir(VarEnv::new())
     }
 }
 
-impl NirKind {
-    pub fn into_nir(self) -> Nir {
+impl<'cx> NirKind<'cx> {
+    pub fn into_nir(self) -> Nir<'cx> {
         Nir::from_kind(self)
     }
 
-    pub fn from_builtin(b: Builtin) -> NirKind {
-        NirKind::from_builtin_env(b, NzEnv::new())
+    pub fn from_builtin(cx: Ctxt<'cx>, b: Builtin) -> Self {
+        NirKind::from_builtin_env(b, NzEnv::new(cx))
     }
-    pub fn from_builtin_env(b: Builtin, env: NzEnv) -> NirKind {
+    pub fn from_builtin_env(b: Builtin, env: NzEnv<'cx>) -> Self {
         BuiltinClosure::new(b, env)
     }
 }
 
-impl Thunk {
-    fn new(env: NzEnv, body: Hir) -> Self {
+impl<'cx> Thunk<'cx> {
+    fn new(env: NzEnv<'cx>, body: Hir<'cx>) -> Self {
         Thunk::Thunk { env, body }
     }
-    fn from_partial_expr(env: NzEnv, expr: ExprKind<Nir>) -> Self {
-        Thunk::PartialExpr { env, expr }
+    fn from_partial_expr(expr: ExprKind<Nir<'cx>>) -> Self {
+        Thunk::PartialExpr { expr }
     }
-    fn eval(self) -> NirKind {
+    fn eval(self) -> NirKind<'cx> {
         match self {
-            Thunk::Thunk { env, body } => normalize_hir(&env, &body),
-            Thunk::PartialExpr { env, expr } => normalize_one_layer(expr, &env),
+            Thunk::Thunk { env, body, .. } => normalize_hir(&env, &body),
+            Thunk::PartialExpr { expr } => normalize_one_layer(expr),
         }
     }
 }
 
-impl Closure {
-    pub fn new(env: &NzEnv, body: Hir) -> Self {
+impl<'cx> Closure<'cx> {
+    pub fn new(env: &NzEnv<'cx>, body: Hir<'cx>) -> Self {
         Closure::Closure {
             env: env.clone(),
             body,
         }
     }
     /// New closure that ignores its argument
-    pub fn new_constant(body: Nir) -> Self {
+    pub fn new_constant(body: Nir<'cx>) -> Self {
         Closure::ConstantClosure { body }
     }
 
-    pub fn apply(&self, val: Nir) -> Nir {
+    pub fn apply(&self, val: Nir<'cx>) -> Nir<'cx> {
         match self {
             Closure::Closure { env, body, .. } => {
                 body.eval(env.insert_value(val, ()))
@@ -329,7 +330,7 @@ impl Closure {
             Closure::ConstantClosure { body, .. } => body.clone(),
         }
     }
-    fn apply_var(&self, var: NzVar) -> Nir {
+    fn apply_var(&self, var: NzVar) -> Nir<'cx> {
         match self {
             Closure::Closure { .. } => {
                 self.apply(Nir::from_kind(NirKind::Var(var)))
@@ -339,13 +340,13 @@ impl Closure {
     }
 
     /// Convert this closure to a Hir expression
-    pub fn to_hir(&self, venv: VarEnv) -> Hir {
+    pub fn to_hir(&self, venv: VarEnv) -> Hir<'cx> {
         self.apply_var(NzVar::new(venv.size()))
             .to_hir(venv.insert())
     }
     /// If the closure variable is free in the closure, return Err. Otherwise, return the value
     /// with that free variable remove.
-    pub fn remove_binder(&self) -> Result<Nir, ()> {
+    pub fn remove_binder(&self) -> Result<Nir<'cx>, ()> {
         match self {
             Closure::Closure { .. } => {
                 let v = NzVar::fresh();
@@ -358,20 +359,20 @@ impl Closure {
     }
 }
 
-impl TextLit {
+impl<'cx> TextLit<'cx> {
     pub fn new(
-        elts: impl Iterator<Item = InterpolatedTextContents<Nir>>,
+        elts: impl Iterator<Item = InterpolatedTextContents<Nir<'cx>>>,
     ) -> Self {
         TextLit(squash_textlit(elts))
     }
-    pub fn interpolate(v: Nir) -> TextLit {
+    pub fn interpolate(v: Nir<'cx>) -> Self {
         TextLit(vec![InterpolatedTextContents::Expr(v)])
     }
-    pub fn from_text(s: String) -> TextLit {
+    pub fn from_text(s: String) -> Self {
         TextLit(vec![InterpolatedTextContents::Text(s)])
     }
 
-    pub fn concat(&self, other: &TextLit) -> TextLit {
+    pub fn concat(&self, other: &Self) -> Self {
         TextLit::new(self.iter().chain(other.iter()).cloned())
     }
     pub fn is_empty(&self) -> bool {
@@ -379,7 +380,7 @@ impl TextLit {
     }
     /// If the literal consists of only one interpolation and not text, return the interpolated
     /// value.
-    pub fn as_single_expr(&self) -> Option<&Nir> {
+    pub fn as_single_expr(&self) -> Option<&Nir<'cx>> {
         use InterpolatedTextContents::Expr;
         if let [Expr(v)] = self.0.as_slice() {
             Some(v)
@@ -398,43 +399,45 @@ impl TextLit {
             None
         }
     }
-    pub fn iter(&self) -> impl Iterator<Item = &InterpolatedTextContents<Nir>> {
+    pub fn iter(
+        &self,
+    ) -> impl Iterator<Item = &InterpolatedTextContents<Nir<'cx>>> {
         self.0.iter()
     }
 }
 
-impl lazy::Eval<NirKind> for Thunk {
-    fn eval(self) -> NirKind {
+impl<'cx> lazy::Eval<NirKind<'cx>> for Thunk<'cx> {
+    fn eval(self) -> NirKind<'cx> {
         self.eval()
     }
 }
 
 /// Compare two values for equality modulo alpha/beta-equivalence.
-impl std::cmp::PartialEq for Nir {
+impl<'cx> std::cmp::PartialEq for Nir<'cx> {
     fn eq(&self, other: &Self) -> bool {
         Rc::ptr_eq(&self.0, &other.0) || self.kind() == other.kind()
     }
 }
-impl std::cmp::Eq for Nir {}
+impl<'cx> std::cmp::Eq for Nir<'cx> {}
 
-impl std::cmp::PartialEq for Thunk {
+impl<'cx> std::cmp::PartialEq for Thunk<'cx> {
     fn eq(&self, _other: &Self) -> bool {
         unreachable!(
             "Trying to compare thunks but we should only compare WHNFs"
         )
     }
 }
-impl std::cmp::Eq for Thunk {}
+impl<'cx> std::cmp::Eq for Thunk<'cx> {}
 
-impl std::cmp::PartialEq for Closure {
+impl<'cx> std::cmp::PartialEq for Closure<'cx> {
     fn eq(&self, other: &Self) -> bool {
         let v = NzVar::fresh();
         self.apply_var(v) == other.apply_var(v)
     }
 }
-impl std::cmp::Eq for Closure {}
+impl<'cx> std::cmp::Eq for Closure<'cx> {}
 
-impl std::fmt::Debug for Nir {
+impl<'cx> std::fmt::Debug for Nir<'cx> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let NirKind::Const(c) = self.kind() {
             return write!(fmt, "{:?}", c);

--- a/dhall/src/semantics/nze/normalize.rs
+++ b/dhall/src/semantics/nze/normalize.rs
@@ -155,7 +155,10 @@ pub fn normalize_one_layer<'cx>(expr: ExprKind<Nir<'cx>>) -> NirKind<'cx> {
 pub fn normalize_hir<'cx>(env: &NzEnv<'cx>, hir: &Hir<'cx>) -> NirKind<'cx> {
     match hir.kind() {
         HirKind::Var(var) => env.lookup_val(*var),
-        HirKind::Import(hir, _) => normalize_hir(env, hir),
+        HirKind::Import(import) => {
+            let typed = env.cx()[import].unwrap_result();
+            normalize_hir(env, &typed.hir)
+        }
         HirKind::Expr(ExprKind::Lam(binder, annot, body)) => {
             let annot = annot.eval(env);
             NirKind::LamClosure {

--- a/dhall/src/semantics/nze/normalize.rs
+++ b/dhall/src/semantics/nze/normalize.rs
@@ -160,6 +160,14 @@ pub fn normalize_hir<'cx>(env: &NzEnv<'cx>, hir: &Hir<'cx>) -> NirKind<'cx> {
             let typed = env.cx()[import].unwrap_result();
             normalize_hir(env, &typed.hir)
         }
+        HirKind::ImportAlternative(alt, left, right) => {
+            let hir = if env.cx()[alt].unwrap_selected() {
+                left
+            } else {
+                right
+            };
+            normalize_hir(env, hir)
+        }
         HirKind::Expr(ExprKind::Lam(binder, annot, body)) => {
             let annot = annot.eval(env);
             NirKind::LamClosure {

--- a/dhall/src/semantics/nze/normalize.rs
+++ b/dhall/src/semantics/nze/normalize.rs
@@ -5,7 +5,7 @@ use crate::semantics::NzEnv;
 use crate::semantics::{Binder, Closure, Hir, HirKind, Nir, NirKind, TextLit};
 use crate::syntax::{ExprKind, InterpolatedTextContents};
 
-pub fn apply_any(f: &Nir, a: Nir) -> NirKind {
+pub fn apply_any<'cx>(f: &Nir<'cx>, a: Nir<'cx>) -> NirKind<'cx> {
     match f.kind() {
         NirKind::LamClosure { closure, .. } => closure.apply(a).kind().clone(),
         NirKind::AppliedBuiltin(closure) => closure.apply(a),
@@ -16,16 +16,16 @@ pub fn apply_any(f: &Nir, a: Nir) -> NirKind {
     }
 }
 
-pub fn squash_textlit(
-    elts: impl Iterator<Item = InterpolatedTextContents<Nir>>,
-) -> Vec<InterpolatedTextContents<Nir>> {
+pub fn squash_textlit<'cx>(
+    elts: impl Iterator<Item = InterpolatedTextContents<Nir<'cx>>>,
+) -> Vec<InterpolatedTextContents<Nir<'cx>>> {
     use std::mem::replace;
     use InterpolatedTextContents::{Expr, Text};
 
-    fn inner(
-        elts: impl Iterator<Item = InterpolatedTextContents<Nir>>,
+    fn inner<'cx>(
+        elts: impl Iterator<Item = InterpolatedTextContents<Nir<'cx>>>,
         crnt_str: &mut String,
-        ret: &mut Vec<InterpolatedTextContents<Nir>>,
+        ret: &mut Vec<InterpolatedTextContents<Nir<'cx>>>,
     ) {
         for contents in elts {
             match contents {
@@ -81,22 +81,22 @@ where
     kvs
 }
 
-pub type Ret = NirKind;
+pub type Ret<'cx> = NirKind<'cx>;
 
-pub fn ret_nir(x: Nir) -> Ret {
+pub fn ret_nir<'cx>(x: Nir<'cx>) -> Ret<'cx> {
     x.into_kind()
 }
-pub fn ret_kind(x: NirKind) -> Ret {
+pub fn ret_kind<'cx>(x: NirKind<'cx>) -> Ret<'cx> {
     x
 }
-pub fn ret_ref(x: &Nir) -> Ret {
+pub fn ret_ref<'cx>(x: &Nir<'cx>) -> Ret<'cx> {
     x.kind().clone()
 }
-pub fn ret_op(x: OpKind<Nir>) -> Ret {
+pub fn ret_op<'cx>(x: OpKind<Nir<'cx>>) -> Ret<'cx> {
     NirKind::Op(x)
 }
 
-pub fn normalize_one_layer(expr: ExprKind<Nir>, env: &NzEnv) -> NirKind {
+pub fn normalize_one_layer<'cx>(expr: ExprKind<Nir<'cx>>) -> NirKind<'cx> {
     use NirKind::{
         Assert, Const, NEListLit, NEOptionalLit, Num, RecordLit, RecordType,
         UnionType,
@@ -106,15 +106,13 @@ pub fn normalize_one_layer(expr: ExprKind<Nir>, env: &NzEnv) -> NirKind {
         ExprKind::Var(..)
         | ExprKind::Lam(..)
         | ExprKind::Pi(..)
-        | ExprKind::Let(..) => {
+        | ExprKind::Let(..)
+        | ExprKind::Builtin(..) => {
             unreachable!("This case should have been handled in normalize_hir")
         }
 
         ExprKind::Const(c) => ret_kind(Const(c)),
         ExprKind::Num(l) => ret_kind(Num(l)),
-        ExprKind::Builtin(b) => {
-            ret_kind(NirKind::from_builtin_env(b, env.clone()))
-        }
         ExprKind::TextLit(elts) => {
             let tlit = TextLit::new(elts.into_iter());
             // Simplify bare interpolation
@@ -154,7 +152,7 @@ pub fn normalize_one_layer(expr: ExprKind<Nir>, env: &NzEnv) -> NirKind {
 }
 
 /// Normalize Hir into WHNF
-pub fn normalize_hir(env: &NzEnv, hir: &Hir) -> NirKind {
+pub fn normalize_hir<'cx>(env: &NzEnv<'cx>, hir: &Hir<'cx>) -> NirKind<'cx> {
     match hir.kind() {
         HirKind::Var(var) => env.lookup_val(*var),
         HirKind::Import(hir, _) => normalize_hir(env, hir),
@@ -178,9 +176,12 @@ pub fn normalize_hir(env: &NzEnv, hir: &Hir) -> NirKind {
             let val = val.eval(env);
             body.eval(env.insert_value(val, ())).kind().clone()
         }
+        HirKind::Expr(ExprKind::Builtin(b)) => {
+            NirKind::from_builtin_env(*b, env.clone())
+        }
         HirKind::Expr(e) => {
             let e = e.map_ref(|hir| hir.eval(env));
-            normalize_one_layer(e, env)
+            normalize_one_layer(e)
         }
     }
 }

--- a/dhall/src/semantics/nze/normalize.rs
+++ b/dhall/src/semantics/nze/normalize.rs
@@ -154,6 +154,7 @@ pub fn normalize_one_layer<'cx>(expr: ExprKind<Nir<'cx>>) -> NirKind<'cx> {
 /// Normalize Hir into WHNF
 pub fn normalize_hir<'cx>(env: &NzEnv<'cx>, hir: &Hir<'cx>) -> NirKind<'cx> {
     match hir.kind() {
+        HirKind::MissingVar(..) => unreachable!("ruled out by typechecking"),
         HirKind::Var(var) => env.lookup_val(*var),
         HirKind::Import(import) => {
             let typed = env.cx()[import].unwrap_result();

--- a/dhall/src/semantics/resolve/cache.rs
+++ b/dhall/src/semantics/resolve/cache.rs
@@ -68,11 +68,12 @@ impl Cache {
 
     pub fn insert<'cx>(
         &self,
+        cx: Ctxt<'cx>,
         hash: &Hash,
         expr: &Typed<'cx>,
     ) -> Result<(), Error> {
         let path = self.entry_path(hash);
-        write_cache_file(&path, expr)
+        write_cache_file(cx, &path, expr)
     }
 }
 
@@ -97,8 +98,12 @@ fn read_cache_file<'cx>(
 }
 
 /// Write a file to the cache.
-fn write_cache_file(path: &Path, expr: &Typed) -> Result<(), Error> {
-    let data = binary::encode(&expr.to_expr())?;
+fn write_cache_file<'cx>(
+    cx: Ctxt<'cx>,
+    path: &Path,
+    expr: &Typed<'cx>,
+) -> Result<(), Error> {
+    let data = binary::encode(&expr.to_expr(cx))?;
     File::create(path)?.write_all(data.as_slice())?;
     Ok(())
 }

--- a/dhall/src/semantics/resolve/cache.rs
+++ b/dhall/src/semantics/resolve/cache.rs
@@ -94,7 +94,7 @@ fn read_cache_file<'cx>(
         }
     }
 
-    Ok(parse_binary(&data)?.skip_resolve()?.typecheck(cx)?)
+    Ok(parse_binary(&data)?.resolve(cx)?.typecheck(cx)?)
 }
 
 /// Write a file to the cache.

--- a/dhall/src/semantics/resolve/env.rs
+++ b/dhall/src/semantics/resolve/env.rs
@@ -17,7 +17,7 @@ pub type CyclesStack = Vec<ImportLocation>;
 pub struct ImportEnv<'cx> {
     cx: Ctxt<'cx>,
     disk_cache: Option<Cache>, // `None` if it failed to initialize
-    mem_cache: HashMap<ImportLocation, ImportResultId>,
+    mem_cache: HashMap<ImportLocation, ImportResultId<'cx>>,
     stack: CyclesStack,
 }
 
@@ -82,7 +82,7 @@ impl<'cx> ImportEnv<'cx> {
     pub fn get_from_mem_cache(
         &self,
         location: &ImportLocation,
-    ) -> Option<ImportResultId> {
+    ) -> Option<ImportResultId<'cx>> {
         Some(*self.mem_cache.get(location)?)
     }
 
@@ -98,7 +98,7 @@ impl<'cx> ImportEnv<'cx> {
     pub fn write_to_mem_cache(
         &mut self,
         location: ImportLocation,
-        result: ImportResultId,
+        result: ImportResultId<'cx>,
     ) {
         self.mem_cache.insert(location, result);
     }

--- a/dhall/src/semantics/resolve/env.rs
+++ b/dhall/src/semantics/resolve/env.rs
@@ -95,9 +95,12 @@ impl<'cx> ImportEnv<'cx> {
         Some(expr)
     }
 
-    /// Invariant: the import must have been fetched.
-    pub fn check_hash(&self, import: ImportId<'cx>) -> Result<(), Error> {
-        check_hash(self.cx(), import)
+    pub fn check_hash(
+        &self,
+        import: ImportId<'cx>,
+        result: ImportResultId<'cx>,
+    ) -> Result<(), Error> {
+        check_hash(self.cx(), import, result)
     }
 
     pub fn write_to_mem_cache(
@@ -108,12 +111,14 @@ impl<'cx> ImportEnv<'cx> {
         self.mem_cache.insert(location, result);
     }
 
-    /// Invariant: the import must have been fetched.
-    pub fn write_to_disk_cache(&self, import: ImportId<'cx>) {
-        let import = &self.cx()[import];
+    pub fn write_to_disk_cache(
+        &self,
+        hash: &Option<Hash>,
+        result: ImportResultId<'cx>,
+    ) {
         if let Some(disk_cache) = self.disk_cache.as_ref() {
-            if let Some(hash) = &import.import.hash {
-                let expr = import.unwrap_result();
+            if let Some(hash) = hash {
+                let expr = &self.cx()[result];
                 let _ = disk_cache.insert(self.cx(), hash, expr);
             }
         }

--- a/dhall/src/semantics/resolve/hir.rs
+++ b/dhall/src/semantics/resolve/hir.rs
@@ -1,7 +1,7 @@
 use crate::error::TypeError;
 use crate::semantics::{type_with, NameEnv, Nir, NzEnv, Tir, TyEnv, Type};
 use crate::syntax::{Expr, ExprKind, Span, V};
-use crate::ToExprOptions;
+use crate::{Ctxt, ToExprOptions};
 
 /// Stores an alpha-normalized variable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -76,8 +76,11 @@ impl Hir {
     ) -> Result<Tir<'hir>, TypeError> {
         type_with(env, self, None)
     }
-    pub fn typecheck_noenv<'hir>(&'hir self) -> Result<Tir<'hir>, TypeError> {
-        self.typecheck(&TyEnv::new())
+    pub fn typecheck_noenv<'hir>(
+        &'hir self,
+        cx: Ctxt<'_>,
+    ) -> Result<Tir<'hir>, TypeError> {
+        self.typecheck(&TyEnv::new(cx))
     }
 
     /// Eval the Hir. It will actually get evaluated only as needed on demand.

--- a/dhall/src/semantics/resolve/hir.rs
+++ b/dhall/src/semantics/resolve/hir.rs
@@ -13,6 +13,8 @@ pub struct AlphaVar {
 pub enum HirKind<'cx> {
     /// A resolved variable (i.e. a DeBruijn index)
     Var(AlphaVar),
+    /// A variable that couldn't be resolved. Detected during resolution, but causes an error during typeck.
+    MissingVar(V),
     /// An import. It must have been resolved by the time we get to typechecking/normalization.
     Import(ImportId<'cx>),
     // Forbidden ExprKind variants: Var, Import, Completion
@@ -104,6 +106,7 @@ fn hir_to_expr<'cx>(
     let kind = match hir.kind() {
         HirKind::Var(v) if opts.alpha => ExprKind::Var(V("_".into(), v.idx())),
         HirKind::Var(v) => ExprKind::Var(env.label_var(*v)),
+        HirKind::MissingVar(v) => ExprKind::Var(v.clone()),
         HirKind::Import(import) => {
             let typed = cx[import].unwrap_result();
             return hir_to_expr(cx, &typed.hir, opts, &mut NameEnv::new());

--- a/dhall/src/semantics/resolve/hir.rs
+++ b/dhall/src/semantics/resolve/hir.rs
@@ -1,5 +1,5 @@
 use crate::error::TypeError;
-use crate::semantics::{type_with, NameEnv, Nir, NzEnv, Tir, TyEnv};
+use crate::semantics::{type_with, typecheck, NameEnv, Nir, NzEnv, Tir, TyEnv};
 use crate::syntax::{Expr, ExprKind, Span, V};
 use crate::{Ctxt, ImportId, ToExprOptions};
 
@@ -81,7 +81,7 @@ impl<'cx> Hir<'cx> {
         &'hir self,
         cx: Ctxt<'cx>,
     ) -> Result<Tir<'cx, 'hir>, TypeError> {
-        self.typecheck(&TyEnv::new(cx))
+        typecheck(cx, self)
     }
 
     /// Eval the Hir. It will actually get evaluated only as needed on demand.

--- a/dhall/src/semantics/resolve/resolve.rs
+++ b/dhall/src/semantics/resolve/resolve.rs
@@ -398,7 +398,7 @@ fn traverse_resolve_expr<'cx>(
 /// Fetch the import and store the result in the global context.
 fn fetch_import<'cx>(
     env: &mut ImportEnv<'cx>,
-    import_id: ImportId,
+    import_id: ImportId<'cx>,
 ) -> Result<(), Error> {
     let cx = env.cx();
     let import = &cx[import_id].import;

--- a/dhall/src/semantics/resolve/resolve.rs
+++ b/dhall/src/semantics/resolve/resolve.rs
@@ -250,7 +250,7 @@ impl ImportLocation {
             ImportMode::Location => {
                 let expr = self.kind.to_location();
                 let hir = skip_resolve_expr(&expr)?;
-                let ty = hir.typecheck_noenv()?.ty().clone();
+                let ty = hir.typecheck_noenv(env.cx())?.ty().clone();
                 (hir, ty)
             }
         };
@@ -463,8 +463,8 @@ fn resolve_with_env<'cx>(
     Ok(Resolved(resolved))
 }
 
-pub fn resolve(parsed: Parsed) -> Result<Resolved, Error> {
-    Ctxt::with_new(|cx| resolve_with_env(&mut ImportEnv::new(cx), parsed))
+pub fn resolve(cx: Ctxt<'_>, parsed: Parsed) -> Result<Resolved, Error> {
+    resolve_with_env(&mut ImportEnv::new(cx), parsed)
 }
 
 pub fn skip_resolve_expr(expr: &Expr) -> Result<Hir, Error> {

--- a/dhall/src/semantics/tck/env.rs
+++ b/dhall/src/semantics/tck/env.rs
@@ -13,7 +13,7 @@ pub struct VarEnv {
 pub struct TyEnv<'cx> {
     cx: Ctxt<'cx>,
     names: NameEnv,
-    items: ValEnv<Type>,
+    items: ValEnv<'cx, Type<'cx>>,
 }
 
 impl VarEnv {
@@ -45,7 +45,7 @@ impl<'cx> TyEnv<'cx> {
         TyEnv {
             cx,
             names: NameEnv::new(),
-            items: ValEnv::new(),
+            items: ValEnv::new(cx),
         }
     }
     pub fn cx(&self) -> Ctxt<'cx> {
@@ -54,34 +54,34 @@ impl<'cx> TyEnv<'cx> {
     pub fn as_varenv(&self) -> VarEnv {
         self.names.as_varenv()
     }
-    pub fn to_nzenv(&self) -> NzEnv {
+    pub fn to_nzenv(&self) -> NzEnv<'cx> {
         self.items.discard_types()
     }
     pub fn as_nameenv(&self) -> &NameEnv {
         &self.names
     }
 
-    pub fn insert_type(&self, x: &Label, ty: Type) -> Self {
+    pub fn insert_type(&self, x: &Label, ty: Type<'cx>) -> Self {
         TyEnv {
             cx: self.cx,
             names: self.names.insert(x),
             items: self.items.insert_type(ty),
         }
     }
-    pub fn insert_value(&self, x: &Label, e: Nir, ty: Type) -> Self {
+    pub fn insert_value(&self, x: &Label, e: Nir<'cx>, ty: Type<'cx>) -> Self {
         TyEnv {
             cx: self.cx,
             names: self.names.insert(x),
             items: self.items.insert_value(e, ty),
         }
     }
-    pub fn lookup(&self, var: AlphaVar) -> Type {
+    pub fn lookup(&self, var: AlphaVar) -> Type<'cx> {
         self.items.lookup_ty(var)
     }
 }
 
-impl<'a, 'cx> From<&'a TyEnv<'cx>> for NzEnv {
-    fn from(x: &'a TyEnv) -> Self {
+impl<'a, 'cx> From<&'a TyEnv<'cx>> for NzEnv<'cx> {
+    fn from(x: &'a TyEnv<'cx>) -> Self {
         x.to_nzenv()
     }
 }

--- a/dhall/src/semantics/tck/typecheck.rs
+++ b/dhall/src/semantics/tck/typecheck.rs
@@ -193,6 +193,14 @@ pub fn type_with<'cx, 'hir>(
             let typed = env.cx()[import].unwrap_result();
             Tir::from_hir(hir, typed.ty.clone())
         }
+        HirKind::ImportAlternative(alt, left, right) => {
+            let hir = if env.cx()[alt].unwrap_selected() {
+                left
+            } else {
+                right
+            };
+            return type_with(env, hir, annot);
+        }
         HirKind::Expr(ExprKind::Var(_)) => {
             unreachable!("Hir should contain no unresolved variables")
         }

--- a/dhall/src/semantics/tck/typecheck.rs
+++ b/dhall/src/semantics/tck/typecheck.rs
@@ -184,7 +184,10 @@ pub fn type_with<'cx, 'hir>(
 ) -> Result<Tir<'cx, 'hir>, TypeError> {
     let tir = match hir.kind() {
         HirKind::Var(var) => Tir::from_hir(hir, env.lookup(*var)),
-        HirKind::Import(_, ty) => Tir::from_hir(hir, ty.clone()),
+        HirKind::Import(import) => {
+            let typed = env.cx()[import].unwrap_result();
+            Tir::from_hir(hir, typed.ty.clone())
+        }
         HirKind::Expr(ExprKind::Var(_)) => {
             unreachable!("Hir should contain no unresolved variables")
         }

--- a/dhall/src/semantics/tck/typecheck.rs
+++ b/dhall/src/semantics/tck/typecheck.rs
@@ -184,6 +184,11 @@ pub fn type_with<'cx, 'hir>(
 ) -> Result<Tir<'cx, 'hir>, TypeError> {
     let tir = match hir.kind() {
         HirKind::Var(var) => Tir::from_hir(hir, env.lookup(*var)),
+        HirKind::MissingVar(var) => mkerr(
+            ErrorBuilder::new(format!("unbound variable `{}`", var))
+                .span_err(hir.span(), "not found in this scope")
+                .format(),
+        )?,
         HirKind::Import(import) => {
             let typed = env.cx()[import].unwrap_result();
             Tir::from_hir(hir, typed.ty.clone())

--- a/dhall/src/semantics/tck/typecheck.rs
+++ b/dhall/src/semantics/tck/typecheck.rs
@@ -62,8 +62,8 @@ fn type_one_layer<'cx>(
             },
         ),
         ExprKind::Builtin(b) => {
-            let t_hir = type_of_builtin(b);
-            typecheck(env.cx(), &t_hir)?.eval_to_type(env)?
+            let t_hir = type_of_builtin(cx, b);
+            typecheck(cx, &t_hir)?.eval_to_type(env)?
         }
         ExprKind::TextLit(interpolated) => {
             let text_type = Type::from_builtin(cx, Builtin::Text);

--- a/dhall/src/semantics/tck/typecheck.rs
+++ b/dhall/src/semantics/tck/typecheck.rs
@@ -29,11 +29,12 @@ pub fn mk_span_err<T, S: ToString>(span: Span, msg: S) -> Result<T, TypeError> {
 
 /// When all sub-expressions have been typed, check the remaining toplevel
 /// layer.
-fn type_one_layer(
-    env: &TyEnv<'_>,
-    ekind: ExprKind<Tir<'_>>,
+fn type_one_layer<'cx>(
+    env: &TyEnv<'cx>,
+    ekind: ExprKind<Tir<'cx, '_>>,
     span: Span,
-) -> Result<Type, TypeError> {
+) -> Result<Type<'cx>, TypeError> {
+    let cx = env.cx();
     let span_err = |msg: &str| mk_span_err(span.clone(), msg);
 
     Ok(match ekind {
@@ -51,18 +52,21 @@ fn type_one_layer(
 
         ExprKind::Const(Const::Type) => Type::from_const(Const::Kind),
         ExprKind::Const(Const::Kind) => Type::from_const(Const::Sort),
-        ExprKind::Num(num) => Type::from_builtin(match num {
-            NumKind::Bool(_) => Builtin::Bool,
-            NumKind::Natural(_) => Builtin::Natural,
-            NumKind::Integer(_) => Builtin::Integer,
-            NumKind::Double(_) => Builtin::Double,
-        }),
+        ExprKind::Num(num) => Type::from_builtin(
+            cx,
+            match num {
+                NumKind::Bool(_) => Builtin::Bool,
+                NumKind::Natural(_) => Builtin::Natural,
+                NumKind::Integer(_) => Builtin::Integer,
+                NumKind::Double(_) => Builtin::Double,
+            },
+        ),
         ExprKind::Builtin(b) => {
             let t_hir = type_of_builtin(b);
             typecheck(env.cx(), &t_hir)?.eval_to_type(env)?
         }
         ExprKind::TextLit(interpolated) => {
-            let text_type = Type::from_builtin(Builtin::Text);
+            let text_type = Type::from_builtin(cx, Builtin::Text);
             for contents in interpolated.iter() {
                 use InterpolatedTextContents::Expr;
                 if let Expr(x) = contents {
@@ -79,7 +83,7 @@ fn type_one_layer(
             }
 
             let t = x.ty().to_nir();
-            Nir::from_builtin(Builtin::Optional)
+            Nir::from_builtin(cx, Builtin::Optional)
                 .app(t)
                 .to_type(Const::Type)
         }
@@ -104,7 +108,9 @@ fn type_one_layer(
             }
 
             let t = x.ty().to_nir();
-            Nir::from_builtin(Builtin::List).app(t).to_type(Const::Type)
+            Nir::from_builtin(cx, Builtin::List)
+                .app(t)
+                .to_type(Const::Type)
         }
         ExprKind::RecordLit(kvs) => {
             // An empty record type has type Type
@@ -171,11 +177,11 @@ fn type_one_layer(
 /// to compare with.
 // We pass the annotation to avoid duplicating the annot checking logic. I hope one day we can use
 // it to handle the annotations in merge/toMap/etc. uniformly.
-pub fn type_with<'hir>(
-    env: &TyEnv<'_>,
-    hir: &'hir Hir,
-    annot: Option<Type>,
-) -> Result<Tir<'hir>, TypeError> {
+pub fn type_with<'cx, 'hir>(
+    env: &TyEnv<'cx>,
+    hir: &'hir Hir<'cx>,
+    annot: Option<Type<'cx>>,
+) -> Result<Tir<'cx, 'hir>, TypeError> {
     let tir = match hir.kind() {
         HirKind::Var(var) => Tir::from_hir(hir, env.lookup(*var)),
         HirKind::Import(_, ty) => Tir::from_hir(hir, ty.clone()),
@@ -268,19 +274,19 @@ pub fn type_with<'hir>(
 
 /// Typecheck an expression and return the expression annotated with its type if type-checking
 /// succeeded, or an error if type-checking failed.
-pub fn typecheck<'hir>(
-    cx: Ctxt<'_>,
-    hir: &'hir Hir,
-) -> Result<Tir<'hir>, TypeError> {
+pub fn typecheck<'cx, 'hir>(
+    cx: Ctxt<'cx>,
+    hir: &'hir Hir<'cx>,
+) -> Result<Tir<'cx, 'hir>, TypeError> {
     type_with(&TyEnv::new(cx), hir, None)
 }
 
 /// Like `typecheck`, but additionally checks that the expression's type matches the provided type.
-pub fn typecheck_with<'hir>(
-    cx: Ctxt<'_>,
-    hir: &'hir Hir,
-    ty: &Hir,
-) -> Result<Tir<'hir>, TypeError> {
+pub fn typecheck_with<'cx, 'hir>(
+    cx: Ctxt<'cx>,
+    hir: &'hir Hir<'cx>,
+    ty: &Hir<'cx>,
+) -> Result<Tir<'cx, 'hir>, TypeError> {
     let ty = typecheck(cx, ty)?.eval_to_type(&TyEnv::new(cx))?;
     type_with(&TyEnv::new(cx), hir, Some(ty))
 }

--- a/dhall/tests/import/success/unit/AlternativeWithWrongVariable1A.dhall
+++ b/dhall/tests/import/success/unit/AlternativeWithWrongVariable1A.dhall
@@ -1,0 +1,1 @@
+\(x: Natural) -> x ? y

--- a/dhall/tests/import/success/unit/AlternativeWithWrongVariable1B.dhall
+++ b/dhall/tests/import/success/unit/AlternativeWithWrongVariable1B.dhall
@@ -1,0 +1,1 @@
+λ(x : Natural) → x

--- a/dhall/tests/import/success/unit/AlternativeWithWrongVariable2A.dhall
+++ b/dhall/tests/import/success/unit/AlternativeWithWrongVariable2A.dhall
@@ -1,0 +1,1 @@
+\(x: Natural) -> (y + missing) ? x

--- a/dhall/tests/import/success/unit/AlternativeWithWrongVariable2B.dhall
+++ b/dhall/tests/import/success/unit/AlternativeWithWrongVariable2B.dhall
@@ -1,0 +1,1 @@
+λ(x : Natural) → x

--- a/serde_dhall/src/options/de.rs
+++ b/serde_dhall/src/options/de.rs
@@ -243,7 +243,7 @@ impl<'a, A> Deserializer<'a, A> {
             let resolved = if self.allow_imports {
                 parsed.resolve(cx)?
             } else {
-                parsed.skip_resolve()?
+                parsed.skip_resolve(cx)?
             };
             let typed = match &T::get_annot(self.annot) {
                 None => resolved.typecheck(cx)?,

--- a/serde_dhall/src/options/de.rs
+++ b/serde_dhall/src/options/de.rs
@@ -250,6 +250,7 @@ impl<'a, A> Deserializer<'a, A> {
                 Some(ty) => resolved.typecheck_with(cx, &ty.to_hir())?,
             };
             Ok(Value::from_nir_and_ty(
+                cx,
                 typed.normalize(cx).as_nir(),
                 typed.ty().as_nir(),
             ))

--- a/serde_dhall/src/options/de.rs
+++ b/serde_dhall/src/options/de.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use dhall::Parsed;
+use dhall::{Ctxt, Parsed};
 
 use crate::options::{HasAnnot, ManualAnnot, NoAnnot, StaticAnnot, TypeAnnot};
 use crate::SimpleType;
@@ -234,24 +234,26 @@ impl<'a, A> Deserializer<'a, A> {
         A: TypeAnnot,
         T: HasAnnot<A>,
     {
-        let parsed = match &self.source {
-            Source::Str(s) => Parsed::parse_str(s)?,
-            Source::File(p) => Parsed::parse_file(p.as_ref())?,
-            Source::BinaryFile(p) => Parsed::parse_binary_file(p.as_ref())?,
-        };
-        let resolved = if self.allow_imports {
-            parsed.resolve()?
-        } else {
-            parsed.skip_resolve()?
-        };
-        let typed = match &T::get_annot(self.annot) {
-            None => resolved.typecheck()?,
-            Some(ty) => resolved.typecheck_with(&ty.to_hir())?,
-        };
-        Ok(Value::from_nir_and_ty(
-            typed.normalize().as_nir(),
-            typed.ty().as_nir(),
-        ))
+        Ctxt::with_new(|cx| {
+            let parsed = match &self.source {
+                Source::Str(s) => Parsed::parse_str(s)?,
+                Source::File(p) => Parsed::parse_file(p.as_ref())?,
+                Source::BinaryFile(p) => Parsed::parse_binary_file(p.as_ref())?,
+            };
+            let resolved = if self.allow_imports {
+                parsed.resolve(cx)?
+            } else {
+                parsed.skip_resolve()?
+            };
+            let typed = match &T::get_annot(self.annot) {
+                None => resolved.typecheck(cx)?,
+                Some(ty) => resolved.typecheck_with(cx, &ty.to_hir())?,
+            };
+            Ok(Value::from_nir_and_ty(
+                typed.normalize(cx).as_nir(),
+                typed.ty().as_nir(),
+            ))
+        })
     }
 
     /// Parses the chosen dhall value with the options provided.

--- a/serde_dhall/src/value.rs
+++ b/serde_dhall/src/value.rs
@@ -335,7 +335,7 @@ impl SimpleValue {
 
     // Converts this to `Hir`, using the optional type annotation. Without the type, things like
     // empty lists and unions will fail to convert.
-    fn to_hir(&self, ty: Option<&SimpleType>) -> Result<Hir> {
+    fn to_hir<'cx>(&self, ty: Option<&SimpleType>) -> Result<Hir<'cx>> {
         use SimpleType as T;
         use SimpleValue as V;
         let hir = |k| Hir::new(HirKind::Expr(k), Span::Artificial);
@@ -481,7 +481,7 @@ impl SimpleType {
         })
     }
 
-    pub(crate) fn to_hir(&self) -> Hir {
+    pub(crate) fn to_hir<'cx>(&self) -> Hir<'cx> {
         let hir = |k| Hir::new(HirKind::Expr(k), Span::Artificial);
         hir(match self {
             SimpleType::Bool => ExprKind::Builtin(Builtin::Bool),

--- a/serde_dhall/src/value.rs
+++ b/serde_dhall/src/value.rs
@@ -8,16 +8,18 @@ use dhall::syntax::{Expr, ExprKind, Span};
 
 use crate::{Error, ErrorKind, FromDhall, Result, ToDhall};
 
+#[derive(Debug, Clone)]
+enum ValueKind {
+    /// Invariant: the value must be printable with the given type.
+    Val(SimpleValue, Option<SimpleType>),
+    Ty(SimpleType),
+}
+
 #[doc(hidden)]
 /// An arbitrary Dhall value.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Value {
-    /// Invariant: in normal form
-    hir: Hir,
-    /// Cached conversions because they are annoying to construct from Hir.
-    /// At most one of them will be `Some`.
-    as_simple_val: Option<SimpleValue>,
-    as_simple_ty: Option<SimpleType>,
+    kind: ValueKind,
 }
 
 /// A value of the kind that can be decoded by `serde_dhall`, e.g. `{ x = True, y = [1, 2, 3] }`.
@@ -204,31 +206,48 @@ pub enum SimpleType {
 }
 
 impl Value {
-    pub(crate) fn from_nir(x: &Nir) -> Self {
-        Value {
-            hir: x.to_hir_noenv(),
-            as_simple_val: SimpleValue::from_nir(x),
-            as_simple_ty: SimpleType::from_nir(x),
-        }
-    }
-
-    pub(crate) fn as_hir(&self) -> &Hir {
-        &self.hir
+    pub(crate) fn from_nir_and_ty(x: &Nir, ty: &Nir) -> Result<Self> {
+        Ok(if let Some(val) = SimpleValue::from_nir(x) {
+            // The type must be simple if the value is simple.
+            let ty = SimpleType::from_nir(ty).unwrap();
+            Value {
+                kind: ValueKind::Val(val, Some(ty)),
+            }
+        } else if let Some(ty) = SimpleType::from_nir(x) {
+            Value {
+                kind: ValueKind::Ty(ty),
+            }
+        } else {
+            let expr = x.to_hir_noenv().to_expr(Default::default());
+            return Err(Error(ErrorKind::Deserialize(format!(
+                "this is neither a simple type nor a simple value: {}",
+                expr
+            ))));
+        })
     }
 
     /// Converts a Value into a SimpleValue.
     pub(crate) fn to_simple_value(&self) -> Option<SimpleValue> {
-        self.as_simple_val.clone()
+        match &self.kind {
+            ValueKind::Val(val, _) => Some(val.clone()),
+            _ => None,
+        }
     }
 
     /// Converts a Value into a SimpleType.
     pub(crate) fn to_simple_type(&self) -> Option<SimpleType> {
-        self.as_simple_ty.clone()
+        match &self.kind {
+            ValueKind::Ty(ty) => Some(ty.clone()),
+            _ => None,
+        }
     }
 
     /// Converts a value back to the corresponding AST expression.
     pub(crate) fn to_expr(&self) -> Expr {
-        self.hir.to_expr(Default::default())
+        match &self.kind {
+            ValueKind::Val(val, ty) => val.to_expr(ty.as_ref()).unwrap(),
+            ValueKind::Ty(ty) => ty.to_expr(),
+        }
     }
 }
 
@@ -411,11 +430,16 @@ impl SimpleValue {
         Ok(hir(kind))
     }
     pub(crate) fn into_value(self, ty: Option<&SimpleType>) -> Result<Value> {
+        // Check that the value is printable with the given type.
+        self.to_hir(ty)?;
         Ok(Value {
-            hir: self.to_hir(ty)?,
-            as_simple_val: Some(self),
-            as_simple_ty: None,
+            kind: ValueKind::Val(self, ty.cloned()),
         })
+    }
+
+    /// Converts back to the corresponding AST expression.
+    pub(crate) fn to_expr(&self, ty: Option<&SimpleType>) -> Result<Expr> {
+        Ok(self.to_hir(ty)?.to_expr(Default::default()))
     }
 }
 
@@ -457,13 +481,6 @@ impl SimpleType {
         })
     }
 
-    pub(crate) fn to_value(&self) -> Value {
-        Value {
-            hir: self.to_hir(),
-            as_simple_val: None,
-            as_simple_ty: Some(self.clone()),
-        }
-    }
     pub(crate) fn to_hir(&self) -> Hir {
         let hir = |k| Hir::new(HirKind::Expr(k), Span::Artificial);
         hir(match self {
@@ -526,10 +543,15 @@ impl ToDhall for Value {
     }
 }
 
-impl Eq for Value {}
-impl PartialEq for Value {
+impl Eq for ValueKind {}
+impl PartialEq for ValueKind {
     fn eq(&self, other: &Self) -> bool {
-        self.hir == other.hir
+        use ValueKind::*;
+        match (self, other) {
+            (Val(a, _), Val(b, _)) => a == b,
+            (Ty(a), Ty(b)) => a == b,
+            _ => false,
+        }
     }
 }
 impl std::fmt::Display for Value {
@@ -555,4 +577,15 @@ fn test_display_simpletype() {
     use SimpleType::*;
     let ty = List(Box::new(Optional(Box::new(Natural))));
     assert_eq!(ty.to_string(), "List (Optional Natural)".to_string())
+}
+
+#[test]
+fn test_display_value() {
+    use SimpleType::*;
+    let ty = List(Box::new(Optional(Box::new(Natural))));
+    let val = SimpleValue::List(vec![]);
+    let val = Value {
+        kind: ValueKind::Val(val, Some(ty)),
+    };
+    assert_eq!(val.to_string(), "[] : List (Optional Natural)".to_string())
 }

--- a/serde_dhall/tests/serde.rs
+++ b/serde_dhall/tests/serde.rs
@@ -226,6 +226,25 @@ mod serde {
             Ok(true)
         );
     }
+
+    #[test]
+    fn test_import() {
+        assert_de(
+            "../dhall-lang/tests/parser/success/unit/BoolLitTrueA.dhall",
+            true,
+        );
+        assert_eq!(
+            serde_dhall::from_str(
+                "../dhall-lang/tests/parser/success/unit/BoolLitTrueA.dhall"
+            )
+            .imports(false)
+            .static_type_annotation()
+            .parse::<bool>()
+            .map_err(|e| e.to_string()),
+            Err("UnexpectedImport(Import { mode: Code, location: Local(Parent, FilePath { file_path: [\"dhall-lang\", \"tests\", \"parser\", \"success\", \"unit\", \"BoolLitTrueA.dhall\"] }), hash: None })".to_string())
+        );
+    }
+
     // TODO: test various builder configurations
     // In particular test cloning and reusing builder
 }

--- a/serde_dhall/tests/simple_value.rs
+++ b/serde_dhall/tests/simple_value.rs
@@ -1,7 +1,7 @@
 mod simple_value {
     use serde::{Deserialize, Serialize};
     use serde_dhall::{
-        from_str, serialize, FromDhall, NumKind, SimpleValue, ToDhall,
+        from_str, serialize, FromDhall, NumKind, SimpleValue, ToDhall, Value,
     };
 
     fn assert_de<T>(s: &str, x: T)
@@ -53,6 +53,18 @@ mod simple_value {
             Foo {
                 foo: bool_true.clone(),
             },
+        );
+
+        // Neither a simple value or a simple type.
+        let not_simple = "Type → Type";
+        assert_eq!(
+            from_str(not_simple)
+                .parse::<Value>()
+                .map_err(|e| e.to_string()),
+            Err(format!(
+                "this is neither a simple type nor a simple value: {}",
+                not_simple
+            ))
         );
     }
 }


### PR DESCRIPTION
This is the first step towards concurrent/async import resolution, as needed for [wasm support](https://github.com/Nadrieril/dhall-rust/issues/166) but also more generally would be cool.
This is an intense PR. The idea is that instead of storing the result of an import in the `Hir` directly, instead we store and index into a global store. Which means I had to make the global store accessible to any code that would need to read an import. I ended up adding a _lot_ of lifetimes x).
So now import resolution runs in two phases: first traverse the ast and replace the imports by their indices, and then go through the imports and resolve them. By making that second step smaller, we'll make it possible to add async and to batch imports.

I got excited with the global store. There's a few more cool things I want to do with it. I hope this is not making the code too much more complicated.
Among other things, once non-import errors don't count for import alternatives (https://github.com/dhall-lang/dhall-lang/issues/1113), we can decouple entirely import resolution from the rest of the code. That would not have been possible before this PR without introducing lots of duplicate work.

cc @basile-henry 