### PR TITLE
Remove redundant semicolons

### DIFF
--- a/dhall/src/builtins.rs
+++ b/dhall/src/builtins.rs
@@ -451,9 +451,10 @@ fn apply_builtin<'cx>(
                             );
 
                             Ret::Nir(Nir::from_kind(NirKind::TextLit(
-                                nze::nir::TextLit::new(
-                                    parts.intersperse(replacement),
-                                ),
+                                nze::nir::TextLit::new(Itertools::intersperse(
+                                    parts,
+                                    replacement,
+                                )),
                             )))
                         }
                     } else {

--- a/dhall/src/lib.rs
+++ b/dhall/src/lib.rs
@@ -7,7 +7,8 @@
     clippy::new_without_default,
     clippy::try_err,
     clippy::unnecessary_wraps,
-    clippy::useless_format
+    clippy::useless_format,
+    clippy::needless_question_mark,
 )]
 
 pub mod builtins;

--- a/dhall/src/semantics/resolve/resolve.rs
+++ b/dhall/src/semantics/resolve/resolve.rs
@@ -558,7 +558,7 @@ pub fn skip_resolve<'cx>(
     parsed: Parsed,
 ) -> Result<Resolved<'cx>, Error> {
     let parsed = Parsed::from_expr_without_imports(parsed.0);
-    Ok(resolve(cx, parsed)?)
+    resolve(cx, parsed)
 }
 
 impl Parsed {

--- a/dhall/src/semantics/tck/typecheck.rs
+++ b/dhall/src/semantics/tck/typecheck.rs
@@ -256,7 +256,7 @@ pub fn type_with<'cx, 'hir>(
         HirKind::Expr(ExprKind::Let(binder, annot, val, body)) => {
             let val_annot = annot
                 .as_ref()
-                .map(|t| Ok(type_with(env, t, None)?.eval_to_type(env)?))
+                .map(|t| type_with(env, t, None)?.eval_to_type(env))
                 .transpose()?;
             let val = type_with(env, &val, val_annot)?;
             let val_nf = val.eval(env);

--- a/dhall/src/syntax/text/parser.rs
+++ b/dhall/src/syntax/text/parser.rs
@@ -279,9 +279,7 @@ impl DhallParser {
 
                 trim_indent(&mut lines);
 
-                lines
-                    .into_iter()
-                    .intersperse(newline)
+                Itertools::intersperse(lines.into_iter(), newline)
                     .flat_map(InterpolatedText::into_iter)
                     .collect::<ParsedText>()
             }

--- a/dhall_proc_macros/src/derive.rs
+++ b/dhall_proc_macros/src/derive.rs
@@ -150,7 +150,7 @@ pub fn derive_static_type_inner(
         quote_spanned! {ty.span()=>
             struct #assert_name #impl_generics #local_where_clause {
                 _phantom: std::marker::PhantomData<(#(#phantoms),*)>
-            };
+            }
         }
     });
 

--- a/serde_dhall/tests/traits.rs
+++ b/serde_dhall/tests/traits.rs
@@ -54,7 +54,7 @@ fn test_static_type() {
     enum E<T> {
         A(T),
         B(String),
-    };
+    }
     assert_eq!(<E<bool>>::static_type(), parse("< A: Bool | B: Text >"));
 
     #[derive(StaticType)]
@@ -62,6 +62,6 @@ fn test_static_type() {
     enum F {
         A,
         B(bool),
-    };
+    }
     assert_eq!(F::static_type(), parse("< A | B: Bool >"));
 }


### PR DESCRIPTION
Hi!

Thanks for your work on dhall! 

The release of rust 1.51 brings a new `redundant_semicolons` lint. Unfortunately, the code that generates type assertions in the procedural macro crate will trip this lint. Because I (and I'm sure other folks) tend to run builds with `-Dwarnings` enabled, this results in build failures, since the compiler can't tell between a spare semicolon in my code, or from third party macros.

The most useful change is in the procedural macro crate, but I've also removed extra semicolons in the tests for good measure.

I see there's also a bunch of style check failures from capitalised acronyms, but a lot of those seem to form part of the public API, which would make fixing those non-trivial.
I'd be tempted to liberally sprinkle `#[allow(clippy::upper_case_acronyms)]` everywhere for now, but some of them exist in generated code, so I'm not sure what you'd like to do abuot that.

Thanks,

