### PR TITLE
Derive: support records in Union Types

### DIFF
--- a/dhall_proc_macros/src/derive.rs
+++ b/dhall_proc_macros/src/derive.rs
@@ -81,11 +81,11 @@ fn derive_for_enum(
                 }
                 syn::Fields::Unnamed(_) => Err(Error::new(
                     v.span(),
-                    "Variants with more than one field are not supported",
+                    "Derive StaticType: Variants with more than one field are not supported",
                 )),
                 syn::Fields::Named(_) => Err(Error::new(
                     v.span(),
-                    "Named variants are not supported",
+                    "Derive StaticType: Named variants are not supported",
                 )),
             }
         })
@@ -111,14 +111,14 @@ pub fn derive_static_type_inner(
         syn::Data::Enum(data) if data.variants.is_empty() => {
             return Err(Error::new(
                 input.span(),
-                "Empty enums are not supported",
+                "Derive StaticType: Empty enums are not supported",
             ))
         }
         syn::Data::Enum(data) => derive_for_enum(data, &mut constraints)?,
         syn::Data::Union(x) => {
             return Err(Error::new(
                 x.union_token.span(),
-                "Unions are not supported",
+                "Derive StaticType: Unions are not supported",
             ))
         }
     };

--- a/serde_dhall/tests/traits.rs
+++ b/serde_dhall/tests/traits.rs
@@ -64,4 +64,14 @@ fn test_static_type() {
         B(bool),
     }
     assert_eq!(F::static_type(), parse("< A | B: Bool >"));
+
+
+    #[derive(StaticType)]
+    #[allow(dead_code)]
+    enum G {
+        A,
+        B(bool),
+        C {a: bool, b: u64}
+    }
+    assert_eq!(G::static_type(), parse("< A | B: Bool | C: { a: Bool, b: Natural } >"))
 }


### PR DESCRIPTION
This adds support for records in variants of union types to the derive StaticType macro, e.g:

```rust
#[derive(Deserialize, Serialize, StaticType)]
enum IntRange {
   Bounded {min: i64, max:  i64},
   LowerThan (i64),
   HigherThan (i64),
   Unbounded
}
```

will result in the following Dhall type:

```dhall
< Bounded: { max : Integer, min : Integer } | HigherThan: Integer | LowerThan: Integer | Unbounded >
```

which can then be used to more conveniently read in nested dhall data.