### PR TITLE
add support for Substitutions

### DIFF
--- a/dhall/src/lib.rs
+++ b/dhall/src/lib.rs
@@ -99,6 +99,11 @@ impl Parsed {
     pub fn to_expr(&self) -> Expr {
         self.0.clone()
     }
+
+    pub fn substitute_name(self, label: syntax::Label, value: Expr) -> Parsed {
+        let Parsed (expr, import_location) = self;
+        Parsed (expr.substitute_name(label, value), import_location)
+    }
 }
 
 impl<'cx> Resolved<'cx> {

--- a/dhall/src/syntax/ast/expr.rs
+++ b/dhall/src/syntax/ast/expr.rs
@@ -182,6 +182,19 @@ impl Expr {
         let data = binary::encode(self)?;
         Ok(crate::utils::sha256_hash(&data))
     }
+
+    /// this wraps the expression into an additional let-binding
+    pub fn substitute_name(self, label: Label, value: Expr) -> Expr {
+        Expr::new(
+            ExprKind::Let(
+                label,
+                None,
+                value,
+                self
+            ),
+            Span::Artificial
+        )
+    }
 }
 
 // Empty enum to indicate that no error can occur

--- a/serde_dhall/src/options/de.rs
+++ b/serde_dhall/src/options/de.rs
@@ -301,7 +301,6 @@ impl<'a, A> Deserializer<'a, A> {
             } else {
                 parsed_with_substs.skip_resolve(cx)?
             };
-            //println!("{:#?}", resolved);
             let typed = match &T::get_annot(self.annot) {
                 None => resolved.typecheck(cx)?,
                 Some(ty) => resolved.typecheck_with(cx, &ty.to_hir())?,

--- a/serde_dhall/src/options/de.rs
+++ b/serde_dhall/src/options/de.rs
@@ -258,14 +258,14 @@ impl<'a, A> Deserializer<'a, A> {
     /// let data = "Newtype.Bar";
     ///
     /// let deserialized = serde_dhall::from_str(data)
-    ///   .inject_types(substs)
+    ///   .with_builtin_types(substs)
     ///   .parse::<Newtype>()
     ///   .unwrap();
     ///
     /// assert_eq!(deserialized, Newtype::Bar);
     ///
     /// ```
-    pub fn inject_types(
+    pub fn with_builtin_types(
         self,
         tys: impl IntoIterator<Item = (String, SimpleType)>,
     ) -> Self {
@@ -285,7 +285,7 @@ impl<'a, A> Deserializer<'a, A> {
         }
     }
 
-    pub fn inject_single_type(self, name: String, ty: SimpleType) -> Self {
+    pub fn with_builtin_type(self, name: String, ty: SimpleType) -> Self {
         Deserializer {
             substitutions: self
                 .substitutions

--- a/serde_dhall/src/options/de.rs
+++ b/serde_dhall/src/options/de.rs
@@ -228,6 +228,43 @@ impl<'a, A> Deserializer<'a, A> {
     //     self
     // }
 
+    /// Sets a Collection of names which should be substituted with
+    /// the given types, i.e. effectively adds built-in type variables
+    /// which do not need to be imported within dhall.
+    ///
+    /// This is especially useful when deserialising into many nested
+    /// structs and enums at once, since it allows exposing the rust
+    /// types to dhall without having to redefine them in both languages
+    /// and manually keep both definitions in sync.
+    ///
+    /// # Example
+    /// ```
+    /// use serde::Deserialize;
+    /// use serde_dhall::StaticType;
+    /// use std::collections::HashMap;
+    ///
+    /// #[derive(Deserialize, StaticType, Debug, PartialEq)]
+    /// enum Newtype {
+    ///   Foo,
+    ///   Bar
+    /// }
+    ///
+    /// let mut substs = HashMap::new();
+    /// substs.insert(
+    ///     "Newtype".to_string(),
+    ///     Newtype::static_type()
+    /// );
+    ///
+    /// let data = "Newtype.Bar";
+    ///
+    /// let deserialized = serde_dhall::from_str(data)
+    ///   .substitute_names(substs)
+    ///   .parse::<Newtype>()
+    ///   .unwrap();
+    ///
+    /// assert_eq!(deserialized, Newtype::Bar);
+    ///
+    /// ```
     pub fn substitute_names(self, substs: HashMap<String, SimpleType>) -> Self {
         Deserializer {
             substitutions: substs

--- a/serde_dhall/tests/serde.rs
+++ b/serde_dhall/tests/serde.rs
@@ -151,7 +151,7 @@ mod serde {
     }
 
     #[test]
-    fn inject_single_type() {
+    fn with_builtin_type() {
         #[derive(Debug, Clone, Deserialize, Serialize, StaticType, Eq, PartialEq)]
         enum Foo {
             X(u64),
@@ -159,7 +159,7 @@ mod serde {
         }
 
         assert_eq!(from_str("Foo.X 1")
-                   .inject_single_type("Foo".to_string(), Foo::static_type())
+                   .with_builtin_type("Foo".to_string(), Foo::static_type())
                    .static_type_annotation()
                    .parse::<Foo>()
                    .unwrap(),
@@ -180,8 +180,8 @@ mod serde {
         }
 
         assert_eq!(from_str("Foo.X Bar.A")
-                   .inject_single_type("Bar".to_string(), Bar::static_type())
-                   .inject_single_type("Foo".to_string(), Foo::static_type())
+                   .with_builtin_type("Bar".to_string(), Bar::static_type())
+                   .with_builtin_type("Foo".to_string(), Foo::static_type())
                    .static_type_annotation()
                    .parse::<Foo>()
                    .unwrap(),
@@ -192,8 +192,8 @@ mod serde {
         substs.insert("Foo".to_string(), Foo::static_type());
 
         assert_eq!(from_str("Foo.X Bar.A")
-                   .inject_types(substs.clone())
-                   .inject_single_type("Bar".to_string(), Bar::static_type())
+                   .with_builtin_types(substs.clone())
+                   .with_builtin_type("Bar".to_string(), Bar::static_type())
                    .static_type_annotation()
                    .parse::<Foo>()
                    .unwrap(),
@@ -205,8 +205,8 @@ mod serde {
         substs.insert("Bar".to_string(), Foo::static_type());
 
         assert_eq!(from_str("Foo.X Bar.A")
-                   .inject_types(substs)
-                   .inject_single_type("Bar".to_string(), Bar::static_type())
+                   .with_builtin_types(substs)
+                   .with_builtin_type("Bar".to_string(), Bar::static_type())
                    .static_type_annotation()
                    .parse::<Foo>()
                    .unwrap(),
@@ -217,7 +217,7 @@ mod serde {
 
     }
     #[test]
-    fn inject_types() {
+    fn with_builtin_types() {
         #[derive(Debug, Clone, Deserialize, Serialize, StaticType, Eq, PartialEq)]
         enum Foo {
             X(u64),
@@ -228,7 +228,7 @@ mod serde {
         substs.insert("Foo".to_string(), Foo::static_type());
 
         assert_eq!(from_str("Foo.X 1")
-                   .inject_types(substs)
+                   .with_builtin_types(substs)
                    .static_type_annotation()
                    .parse::<Foo>()
                    .unwrap(),

--- a/serde_dhall/tests/serde.rs
+++ b/serde_dhall/tests/serde.rs
@@ -3,6 +3,7 @@ mod serde {
     use serde_dhall::{
         from_str, serialize, FromDhall, StaticType, ToDhall, Value,
     };
+    use std::collections;
 
     fn assert_de<T>(s: &str, x: T)
     where
@@ -147,6 +148,26 @@ mod serde {
             .static_type_annotation()
             .parse::<Bar>()
             .is_err());
+    }
+
+    #[test]
+    fn substitutions() {
+        #[derive(Debug, Clone, Deserialize, Serialize, StaticType, Eq, PartialEq)]
+        enum Foo {
+            X(u64),
+            Y(i64),
+        }
+
+        let mut substs = collections::HashMap::new();
+        substs.insert("Foo".to_string(), Foo::static_type());
+
+        assert_eq!(from_str("Foo.X 1")
+                   .substitute_names(substs)
+                   .static_type_annotation()
+                   .parse::<Foo>()
+                   .unwrap(),
+                   Foo::X(1)
+        )
     }
 
     #[test]


### PR DESCRIPTION
this adds subsititutions, which work similar to the `Dhall.substitutions` mechanism of the Haskell dhall package, which take a hashmap of simple types that should be available within dhall:

```rust
#[derive(Debug, Clone, Deserialize, Serialize, StaticType, Eq, PartialEq)]
enum Foo {
    X(u64),
    Y(i64),
}

let mut substs = collections::HashMap::new();
substs.insert("Foo".to_string(), Foo::static_type());

assert_eq!(from_str("Foo.X 1")
           .substitute_names(substs)
           .static_type_annotation()
           .parse::<Foo>()
           .unwrap(),
           Foo::X(1)
```

The idea behind this is to make it easy to add programmer-defined types which may be used in configs for programs, without forcing the program's users to re-import the same type definitions each time (or the programmers to keep the dhall-based definitions in sync with their rust types, since these are now generated automatically).

Note that the current implementation is a bit hacky in places — some types which _feel_ like they should be internal to the `dhall` create are now used in `serde_dhall` (even if, strictly speaking, they are not), and instead of implementing substitutions during type checking or in the semantics, it just wraps the AST into additional let-bindings before anything else is done with it — I needed this for a little project of mine and was in a bit of a hurry, but thought I'd still share this here in case you want to merge it (if I find the time, I'll probably clean the code up a bit more in the next week or so).